### PR TITLE
Store service logs

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/logs.py
+++ b/core/libs/commonwealth/commonwealth/utils/logs.py
@@ -1,8 +1,11 @@
 import logging
+from datetime import datetime
 from logging import LogRecord
+from pathlib import Path
 from types import FrameType
 from typing import Optional, Union
 
+import appdirs
 from loguru import logger
 
 
@@ -23,3 +26,23 @@ class InterceptHandler(logging.Handler):
             depth += 1
 
         logger.opt(depth=depth, exception=record.exc_info).log(level, record.getMessage())
+
+
+def get_new_log_path(service_name: str) -> Path:
+    """Get default Path to a new log for a given service."""
+    # Prevent problematic service names
+    if service_name == "":
+        raise ValueError("Service name cannot be empty")
+    if "/" in service_name:
+        raise ValueError("Service name cannot contain forward slash character ('/').")
+    if "." in service_name:
+        raise ValueError("Service name cannot contain extension-separation character ('.').")
+
+    # Create folder for service logs if it doesn't exist yet
+    default_log_folder = Path(appdirs.user_log_dir())
+    service_log_folder = default_log_folder.joinpath(service_name)
+    service_log_folder.mkdir(parents=True, exist_ok=True)
+
+    # Returned log path are service-specific and store datetime information
+    datetime_now = datetime.now().strftime("%m-%d-%Y_%H:%M:%S")
+    return service_log_folder.joinpath(f"logfile_{datetime_now}.log")

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Set
 
 from commonwealth.utils.apis import PrettyJSONResponse
-from commonwealth.utils.logs import InterceptHandler
+from commonwealth.utils.logs import InterceptHandler, get_new_log_path
 from fastapi import Body, FastAPI, File, HTTPException, Response, UploadFile, status
 from fastapi.staticfiles import StaticFiles
 from fastapi_versioning import VersionedFastAPI, version
@@ -18,6 +18,7 @@ from uvicorn import Config, Server
 from ArduPilotManager import ArduPilotManager
 from exceptions import InvalidFirmwareFile
 from mavlink_proxy.Endpoint import Endpoint
+from settings import SERVICE_NAME
 from typedefs import Firmware, Platform, SITLFrame, Vehicle
 
 FRONTEND_FOLDER = Path.joinpath(Path(__file__).parent.absolute(), "frontend")
@@ -28,6 +29,7 @@ parser.add_argument("-s", "--sitl", help="run SITL instead of connecting any boa
 args = parser.parse_args()
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
+logger.add(get_new_log_path(SERVICE_NAME))
 
 
 app = FastAPI(

--- a/core/services/ardupilot_manager/settings.py
+++ b/core/services/ardupilot_manager/settings.py
@@ -6,9 +6,11 @@ from typing import Any, Dict, Union, cast
 import appdirs
 from loguru import logger
 
+SERVICE_NAME = "ardupilot-manager"
+
 
 class Settings:
-    app_name = "ardupilot-manager"
+    app_name = SERVICE_NAME
     settings_path = Path(appdirs.user_config_dir(app_name))
     settings_file = Path.joinpath(settings_path, "settings.json")
     firmware_folder = Path.joinpath(settings_path, "firmware")

--- a/core/services/bridget/main.py
+++ b/core/services/bridget/main.py
@@ -4,7 +4,7 @@ from typing import Any, List
 
 import uvicorn
 from commonwealth.utils.apis import PrettyJSONResponse
-from commonwealth.utils.logs import InterceptHandler
+from commonwealth.utils.logs import InterceptHandler, get_new_log_path
 from fastapi import FastAPI, Response, status
 from fastapi.responses import HTMLResponse
 from fastapi_versioning import VersionedFastAPI, version
@@ -12,7 +12,10 @@ from loguru import logger
 
 from bridget import BridgeSpec, Bridget
 
+SERVICE_NAME = "bridget"
+
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
+logger.add(get_new_log_path(SERVICE_NAME))
 
 app = FastAPI(
     title="Bridget API",

--- a/core/services/cable_guy/main.py
+++ b/core/services/cable_guy/main.py
@@ -9,7 +9,7 @@ from typing import Any, List
 import uvicorn
 from commonwealth.utils.apis import PrettyJSONResponse
 from commonwealth.utils.decorators import temporary_cache
-from commonwealth.utils.logs import InterceptHandler
+from commonwealth.utils.logs import InterceptHandler, get_new_log_path
 from fastapi import Body, FastAPI, HTTPException, status
 from fastapi.staticfiles import StaticFiles
 from fastapi_versioning import VersionedFastAPI, version
@@ -21,6 +21,8 @@ from api.manager import (
     InterfaceConfiguration,
     InterfaceMode,
 )
+
+SERVICE_NAME = "cable-guy"
 
 parser = argparse.ArgumentParser(description="CableGuy service for Blue Robotics Companion")
 parser.add_argument(
@@ -43,6 +45,7 @@ if args.default_config == "bluerov2":
 manager = EthernetManager(default_config, dhcp_gateway)
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
+logger.add(get_new_log_path(SERVICE_NAME))
 
 HTML_FOLDER = Path.joinpath(Path(__file__).parent.absolute(), "html")
 

--- a/core/services/commander/main.py
+++ b/core/services/commander/main.py
@@ -7,13 +7,16 @@ from typing import Any, Callable
 
 import appdirs
 import uvicorn
-from commonwealth.utils.logs import InterceptHandler
+from commonwealth.utils.logs import InterceptHandler, get_new_log_path
 from fastapi import FastAPI, HTTPException, Response, status
 from fastapi.responses import HTMLResponse
 from fastapi_versioning import VersionedFastAPI, version
 from loguru import logger
 
+SERVICE_NAME = "commander"
+
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
+logger.add(get_new_log_path(SERVICE_NAME))
 
 app = FastAPI(
     title="Commander API",

--- a/core/services/nmea_injector/main.py
+++ b/core/services/nmea_injector/main.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any, List
 
 from commonwealth.utils.apis import PrettyJSONResponse
-from commonwealth.utils.logs import InterceptHandler
+from commonwealth.utils.logs import InterceptHandler, get_new_log_path
 from fastapi import FastAPI, Response, status
 from fastapi.responses import HTMLResponse
 from fastapi_versioning import VersionedFastAPI, version
@@ -14,6 +14,8 @@ from uvicorn import Config, Server
 
 from TrafficController import NMEASocket, SocketKind, TrafficController
 
+SERVICE_NAME = "nmea-injector"
+
 parser = argparse.ArgumentParser(description="NMEA Injector service for Blue Robotics Companion")
 parser.add_argument("-u", "--udp", type=int, help="change the default UDP input port")
 parser.add_argument("-t", "--tcp", type=int, help="change the default TCP input port")
@@ -21,6 +23,7 @@ parser.add_argument("-t", "--tcp", type=int, help="change the default TCP input 
 args = parser.parse_args()
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
+logger.add(get_new_log_path(SERVICE_NAME))
 
 
 app = FastAPI(

--- a/core/services/ping/main.py
+++ b/core/services/ping/main.py
@@ -5,7 +5,7 @@ import logging
 from typing import Any, List
 
 from commonwealth.utils.apis import PrettyJSONResponse
-from commonwealth.utils.logs import InterceptHandler
+from commonwealth.utils.logs import InterceptHandler, get_new_log_path
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
 from fastapi_versioning import VersionedFastAPI, version
@@ -16,6 +16,8 @@ from pingmanager import PingManager
 from pingprober import PingProber
 from portwatcher import PortWatcher
 from typedefs import PingDeviceDescriptorModel
+
+SERVICE_NAME = "ping"
 
 app = FastAPI(
     title="Ping Manager API",
@@ -67,6 +69,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     logging.basicConfig(handlers=[InterceptHandler()], level=0)
+    logger.add(get_new_log_path(SERVICE_NAME))
 
     loop = asyncio.new_event_loop()
 

--- a/core/services/wifi/main.py
+++ b/core/services/wifi/main.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, List, Optional
 
 from commonwealth.utils.apis import PrettyJSONResponse
-from commonwealth.utils.logs import InterceptHandler
+from commonwealth.utils.logs import InterceptHandler, get_new_log_path
 from fastapi import FastAPI, HTTPException, status
 from fastapi.staticfiles import StaticFiles
 from fastapi_versioning import VersionedFastAPI, version
@@ -22,8 +22,10 @@ from typedefs import SavedWifiNetwork, ScannedWifiNetwork, WifiCredentials
 from WifiManager import WifiManager
 
 FRONTEND_FOLDER = Path.joinpath(Path(__file__).parent.absolute(), "frontend")
+SERVICE_NAME = "wifi-manager"
 
 logging.basicConfig(handlers=[InterceptHandler()], level=0)
+logger.add(get_new_log_path(SERVICE_NAME))
 
 logger.info("Starting Wifi Manager.")
 wifi_manager = WifiManager()

--- a/core/tools/ardupilot_tools/bootstrap.sh
+++ b/core/tools/ardupilot_tools/bootstrap.sh
@@ -23,7 +23,7 @@ USER_SITE_PACKAGES="$(python -m site --user-site)"
 mkdir -p $USER_SITE_PACKAGES
 
 ### Ardupilot's decoder is used to parse and validate firmware ELF files
-COMMIT_HASH=bdb56b20b5cf1f8bf3716c88edb51461f18709a9
+COMMIT_HASH=b839ddcc00f4cb89d89aaa8cf0cb03298d2f00b4
 LOCAL_PATH_DECODER="${USER_SITE_PACKAGES}/ardupilot_fw_decoder.py"
-REMOTE_URL_DECODER="https://raw.githubusercontent.com/patrickelectric/ardupilot/${COMMIT_HASH}/Tools/scripts/firmware_version_decoder.py"
+REMOTE_URL_DECODER="https://raw.githubusercontent.com/ArduPilot/ardupilot/${COMMIT_HASH}/Tools/scripts/firmware_version_decoder.py"
 wget "$REMOTE_URL_DECODER" -O "$LOCAL_PATH_DECODER"


### PR DESCRIPTION
This patch introduces storage of the service logs.

All logs are stored under the root user log folder (/root/.cache/log), with each service having its own folder.

![image](https://user-images.githubusercontent.com/6551040/153499370-d0e70c71-0c0f-466c-9d1e-f17e776df8cc.png)

The files use the following name pattern: `logfile_MM_DD_YY_HH_mm_SS.log`

![image](https://user-images.githubusercontent.com/6551040/153499544-a0586c3c-16e3-4014-adfa-55e1d7888c22.png)

