### PR TITLE
frontend: Limit number of notifications

### DIFF
--- a/core/frontend/src/components/notifications/ConfigMenu.vue
+++ b/core/frontend/src/components/notifications/ConfigMenu.vue
@@ -6,7 +6,7 @@
     <v-list>
       <v-list-item>
         <v-switch
-          :value="showOld"
+          :input-value="showOld"
           color="blue lighten-1"
           @change="emitShowOldChange"
         />

--- a/core/frontend/src/components/notifications/NotificationManager.vue
+++ b/core/frontend/src/components/notifications/NotificationManager.vue
@@ -89,7 +89,7 @@ export default Vue.extend({
   data() {
     return {
       show_config_menu: false,
-      show_old_messages: true,
+      show_old_messages: false,
       timestamp: new Date(),
       seconds_recent: 60,
       active_intervals: [] as number[],

--- a/core/frontend/src/components/notifications/NotificationManager.vue
+++ b/core/frontend/src/components/notifications/NotificationManager.vue
@@ -93,6 +93,7 @@ export default Vue.extend({
       timestamp: new Date(),
       seconds_recent: 60,
       active_intervals: [] as number[],
+      max_number_notifications: 100,
     }
   },
   computed: {
@@ -104,12 +105,12 @@ export default Vue.extend({
         const date_now = new Date()
         const date_notification = new Date(cumulated.notification.time_created)
         return differenceInSeconds(date_now, date_notification) < this.seconds_recent
-      })
+      }).slice(-this.max_number_notifications)
     },
     notifications_to_show(): CumulatedNotification[] {
       const notifications_to_show = this.show_old_messages ? this.notifications : this.recent_notifications
       // Returning the notifications reversed to show the last ones first
-      return notifications_to_show.slice().reverse()
+      return notifications_to_show.reverse()
     },
   },
   mounted() {


### PR DESCRIPTION
- Limit number of recent notifications to 100
- Fix button to show/hide old notifications
- Don't show old notifications by default (prevent performance issues)

Fix #756 