### PR TITLE
Revert "Core: Mavlink2Rest: use internal endpoint for communications"

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -222,6 +222,15 @@ class ArduPilotManager(metaclass=Singleton):
                 enabled=True,
             ),
             Endpoint(
+                "MAVLink2Rest",
+                self.settings.app_name,
+                EndpointType.UDPClient,
+                "127.0.0.1",
+                14000,
+                persistent=True,
+                protected=True,
+            ),
+            Endpoint(
                 "Internal Link",
                 self.settings.app_name,
                 EndpointType.UDPServer,

--- a/core/start-companion-core
+++ b/core/start-companion-core
@@ -26,7 +26,7 @@ SERVICES=(
     'nmea_injector',"$SERVICES_PATH/nmea_injector/main.py"
     'helper',"$SERVICES_PATH/helper/main.py"
     'video',"mavlink-camera-manager --default-settings BlueROVUDP  --mavlink udpout:127.0.0.1:14001 --verbose"
-    'mavlink2rest',"mavlink2rest --connect=udpout:127.0.0.1:14001 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
+    'mavlink2rest',"mavlink2rest --connect=udpin:127.0.0.1:14000 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
     'linux2rest',"linux2rest"
     'filebrowser',"filebrowser --database /etc/filebrowser/filebrowser.db --baseurl /file-browser"
     'versionchooser',"$SERVICES_PATH/versionchooser/main.py"


### PR DESCRIPTION
This reverts commit fd9c3c4e2e04744b1f6e123b28236bac5630fe5c.

It turns out that mavlink-router also doesn't support multiple clients in server mode. Why the hell do they call it a server at all?

anyway. the symptom is that mavlink2rest and the cameramanager fight for the endpoint, which causes camera packages not to arrive to qgc, and messages not to arrive to mavlink2rest (not even heartbeats).

image up at williangalvani/companion-core:mavlink2restendpoint