### PR TITLE
core: cable-guy: More than one IP address

### DIFF
--- a/core/frontend/src/components/ethernet/AddressCreationDialog.vue
+++ b/core/frontend/src/components/ethernet/AddressCreationDialog.vue
@@ -1,0 +1,147 @@
+<template>
+  <v-dialog
+    width="350"
+    :value="show"
+    @input="showDialog"
+  >
+    <v-card>
+      <v-card-title>New IP address on '{{ interfaceName }}'</v-card-title>
+
+      <v-card-text class="d-flex flex-column">
+        <v-form
+          ref="form"
+          lazy-validation
+        >
+          <v-select
+            v-model="mode"
+            :items="mode_types"
+            label="Mode"
+            :rules="[validate_required_field]"
+          />
+
+          <v-text-field
+            v-model="ip_address"
+            :rules="[is_valid_ip_input]"
+            :disabled="!editable_ip"
+            label="IP address"
+          />
+
+          <v-btn
+            color="success"
+            class="mr-4"
+            @click="createNewAddress"
+          >
+            Create
+          </v-btn>
+        </v-form>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+import ethernet from '@/store/ethernet'
+import notifications from '@/store/notifications'
+import { AddressMode } from '@/types/ethernet'
+import { ethernet_service } from '@/types/frontend_services'
+import { VForm } from '@/types/vuetify'
+import back_axios from '@/utils/api'
+import { isIpAddress, isNotEmpty } from '@/utils/pattern_validators'
+
+export default Vue.extend({
+  name: 'NetworkCard',
+  model: {
+    prop: 'show',
+    event: 'change',
+  },
+  props: {
+    show: {
+      type: Boolean,
+      default: false,
+    },
+    interfaceName: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      mode: AddressMode.unmanaged,
+      ip_address: '',
+    }
+  },
+
+  computed: {
+    mode_types(): {value: AddressMode, text: string}[] {
+      return Object.entries(AddressMode).map(
+        (mode) => ({ value: mode[1], text: this.showable_mode_name(mode[1]) }),
+      )
+    },
+    editable_ip(): boolean {
+      return this.mode === AddressMode.unmanaged
+    },
+    form(): VForm {
+      return this.$refs.form as VForm
+    },
+  },
+  watch: {
+    show(val: boolean): void {
+      if (val === false) {
+        this.mode = AddressMode.unmanaged
+        this.ip_address = ''
+      }
+    },
+  },
+  methods: {
+    validate_required_field(input: string): (true | string) {
+      return isNotEmpty(input) ? true : 'Required field.'
+    },
+    is_valid_ip_input(input: string): (true | string) {
+      if (this.mode === AddressMode.unmanaged) {
+        return isIpAddress(input) ? true : 'Invalid IP address.'
+      }
+      return true
+    },
+    showable_mode_name(mode: AddressMode): string {
+      switch (mode) {
+        case AddressMode.client: return 'Dynamic IP'
+        case AddressMode.server: return 'DHCP Server'
+        case AddressMode.unmanaged: return 'Static IP'
+        default: return 'Undefined mode'
+      }
+    },
+    async createNewAddress(): Promise<boolean> {
+      // Validate form before proceeding with API request
+      if (!this.form.validate()) {
+        return false
+      }
+      ethernet.setUpdatingInterfaces(true)
+      this.showDialog(false)
+
+      await back_axios({
+        method: 'post',
+        url: `${ethernet.API_URL}/address`,
+        timeout: 10000,
+        params: {
+          interface_name: this.interfaceName,
+          mode: this.mode,
+          ip_address: this.ip_address === '' ? null : this.ip_address,
+        },
+      })
+        .then(() => {
+          this.form.reset()
+        })
+        .catch((error) => {
+          const message = `Could not create new address on ${this.interfaceName}: ${error.message}.`
+          notifications.pushError({ service: ethernet_service, type: 'ETHERNET_ADDRESS_CREATION_FAIL', message })
+        })
+      return true
+    },
+    showDialog(state: boolean) {
+      this.$emit('change', state)
+    },
+  },
+})
+</script>

--- a/core/frontend/src/components/ethernet/EthernetManager.vue
+++ b/core/frontend/src/components/ethernet/EthernetManager.vue
@@ -9,7 +9,6 @@
         :key="key"
         class="available-interface"
         :adapter="ethernet_interface"
-        @edit="updateInterface"
       />
     </v-expansion-panels>
     <v-container v-else-if="updating_interfaces">
@@ -28,10 +27,7 @@ import Vue from 'vue'
 
 import SpinningLogo from '@/components/common/SpinningLogo.vue'
 import ethernet from '@/store/ethernet'
-import notifications from '@/store/notifications'
 import { EthernetInterface } from '@/types/ethernet'
-import { ethernet_service } from '@/types/frontend_services'
-import back_axios from '@/utils/api'
 
 import InterfaceCard from './InterfaceCard.vue'
 
@@ -50,21 +46,6 @@ export default Vue.extend({
     },
     updating_interfaces(): boolean {
       return ethernet.updating_interfaces
-    },
-  },
-  methods: {
-    async updateInterface(ethernet_interface: EthernetInterface): Promise<void> {
-      ethernet.setUpdatingInterfaces(true)
-      await back_axios({
-        method: 'post',
-        url: `${ethernet.API_URL}/ethernet`,
-        timeout: 5000,
-        data: ethernet_interface,
-      })
-        .catch((error) => {
-          const message = `Could not update ethernet interface: ${error.message}`
-          notifications.pushError({ service: ethernet_service, type: 'ETHERNET_INTERFACE_UPDATE_FAIL', message })
-        })
     },
   },
 })

--- a/core/frontend/src/components/ethernet/InterfaceCard.vue
+++ b/core/frontend/src/components/ethernet/InterfaceCard.vue
@@ -2,100 +2,50 @@
   <v-expansion-panel
     flat
   >
-    <v-expansion-panel-header>
+    <v-expansion-panel-header class="interface-header">
       {{ adapter.name }}
       <v-spacer />
       {{ status_info }}
     </v-expansion-panel-header>
 
     <v-expansion-panel-content>
-      <v-row align="center">
-        <v-col cols="10">
-          <v-form
-            ref="form"
-            lazy-validation
-          >
-            <v-simple-table dense>
-              <template #default>
-                <tbody>
-                  <tr>
-                    <td>Name</td>
-                    <td>{{ adapter.name }}</td>
-                  </tr>
-
-                  <tr>
-                    <td>Mode</td>
-                    <td v-if="!editing">
-                      {{ showable_mode_name(adapter.configuration.mode) }}
-                    </td>
-
-                    <td v-else>
-                      <v-select
-                        v-model="mode_set"
-                        dense
-                        :items="mode_types"
-                        :rules="[validate_required_field]"
-                      />
-                    </td>
-                  </tr>
-
-                  <tr>
-                    <td>IP address</td>
-                    <td v-if="!editing">
-                      {{ current_ip }}
-                    </td>
-
-                    <td
-                      v-else
-                    >
-                      <div v-if="editable_ip">
-                        <v-text-field
-                          v-model="ip_set"
-                          label="IP Address"
-                          single-line
-                          dense
-                          class="pa-1"
-                          :rules="[is_ip_address]"
-                        />
-                      </div>
-                    </td>
-                  </tr>
-                </tbody>
-              </template>
-            </v-simple-table>
-          </v-form>
-        </v-col>
-
-        <v-col cols="2">
+      <v-container>
+        <v-row
+          v-for="(address, key) in adapter.addresses"
+          :key="key"
+          height="50"
+          align="center"
+        >
+          <v-col cols="5">
+            {{ address.ip }}
+          </v-col>
+          <v-col cols="5">
+            {{ showable_mode_name(address.mode) }}
+          </v-col>
+          <v-col cols="2">
+            <v-btn
+              icon
+              class="text-center"
+              @click.native.stop="deleteAddress(address.ip)"
+            >
+              <v-icon>
+                mdi-delete-circle
+              </v-icon>
+            </v-btn>
+          </v-col>
+        </v-row>
+        <v-row justify="center">
           <v-btn
-            v-if="!editing"
-            icon
-            @click="changeEditing(true)"
+            @click.native.stop="openAddressCreationDialog"
           >
-            <v-icon>mdi-pencil</v-icon>
+            Add new address
           </v-btn>
-
-          <v-container v-else>
-            <v-row>
-              <v-btn
-                icon
-                @click="emitEdit()"
-              >
-                <v-icon>mdi-check</v-icon>
-              </v-btn>
-            </v-row>
-
-            <v-row>
-              <v-btn
-                icon
-                @click="changeEditing(false)"
-              >
-                <v-icon>mdi-close</v-icon>
-              </v-btn>
-            </v-row>
-          </v-container>
-        </v-col>
-      </v-row>
+          <address-creation-dialog
+            v-model="show_creation_dialog"
+            :interface-name="adapter.name"
+          />
+        </v-row>
+      </v-container>
     </v-expansion-panel-content>
   </v-expansion-panel>
 </template>
@@ -103,96 +53,71 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue'
 
-import { EthernetInterface, InterfaceConfiguration, InterfaceMode } from '@/types/ethernet'
-import { VForm } from '@/types/vuetify'
-import { isIpAddress, isNotEmpty } from '@/utils/pattern_validators'
+import ethernet from '@/store/ethernet'
+import notifications from '@/store/notifications'
+import { AddressMode, EthernetInterface } from '@/types/ethernet'
+import { ethernet_service } from '@/types/frontend_services'
+import back_axios from '@/utils/api'
+
+import AddressCreationDialog from './AddressCreationDialog.vue'
 
 export default Vue.extend({
-  name: 'NetworkCard',
+  name: 'InterfaceCard',
+  components: {
+    AddressCreationDialog,
+  },
   props: {
     adapter: {
       type: Object as PropType<EthernetInterface>,
       required: true,
     },
   },
+
   data() {
     return {
-      editing: false,
-      mode_set: this.adapter.configuration.mode,
-      ip_set: this.adapter.configuration.ip,
+      show_creation_dialog: false,
     }
   },
   computed: {
-    mode_types(): {value: InterfaceMode, text: string}[] {
-      return Object.entries(InterfaceMode).map(
-        (mode) => ({ value: mode[1], text: this.showable_mode_name(mode[1]) }),
-      )
-    },
     is_connected(): boolean {
       return this.adapter.info ? this.adapter.info.connected : false
     },
-    current_ip(): string {
-      return this.adapter.configuration.ip === 'undefined' ? 'Undefined IP' : this.adapter.configuration.ip
-    },
-    editable_ip(): boolean {
-      return this.mode_set === InterfaceMode.unmanaged
-    },
     status_info(): string {
-      if (!this.is_connected) {
-        return 'Not connected'
-      }
-
-      if (this.adapter.configuration.mode === InterfaceMode.server) {
-        return 'DHCP Server running'
-      }
-      return this.adapter.configuration.ip
-    },
-    form(): VForm {
-      return this.$refs.form as VForm
+      return this.is_connected ? 'Connected' : 'Not connected'
     },
   },
   methods: {
-    validate_required_field(input: string): (true | string) {
-      return isNotEmpty(input) ? true : 'Required field.'
-    },
-    is_ip_address(input: string): (true | string) {
-      return isIpAddress(input) ? true : 'Invalid IP address.'
-    },
-    showable_mode_name(mode: InterfaceMode): string {
+    showable_mode_name(mode: AddressMode): string {
       switch (mode) {
-        case InterfaceMode.client: return 'Dynamic IP'
-        case InterfaceMode.server: return 'DHCP Server'
-        case InterfaceMode.unmanaged: return 'Static IP'
+        case AddressMode.client: return 'Dynamic IP'
+        case AddressMode.server: return 'DHCP Server'
+        case AddressMode.unmanaged: return 'Static IP'
         default: return 'Undefined mode'
       }
     },
-    changeEditing(state: boolean): void {
-      this.editing = state
+    openAddressCreationDialog(): void {
+      this.show_creation_dialog = true
     },
-    emitEdit() {
-      if (!this.form.validate()) {
-        return
-      }
-      const interface_configuration: InterfaceConfiguration = {
-        mode: this.mode_set,
-        ip: this.ip_set,
-      }
-      const changed_interface: EthernetInterface = {
-        name: this.adapter.name,
-        configuration: interface_configuration,
-      }
-      this.$emit('edit', changed_interface)
+    async deleteAddress(ip: string): Promise<void> {
+      ethernet.setUpdatingInterfaces(true)
 
-      this.changeEditing(false)
-      this.ip_set = ''
+      await back_axios({
+        method: 'delete',
+        url: `${ethernet.API_URL}/address`,
+        timeout: 10000,
+        params: { interface_name: this.adapter.name, ip_address: ip },
+      })
+        .catch((error) => {
+          const message = `Could not delete address '${ip}' on '${this.adapter.name}': ${error.message}.`
+          notifications.pushError({ service: ethernet_service, type: 'ETHERNET_ADDRESS_DELETE_FAIL', message })
+        })
     },
   },
 })
 </script>
 
 <style>
-.adapter-mode
-{
-  cursor: pointer;
+.interface-header {
+  background-color: #2799D2
 }
 </style>

--- a/core/frontend/src/types/ethernet.ts
+++ b/core/frontend/src/types/ethernet.ts
@@ -1,12 +1,12 @@
-export enum InterfaceMode {
+export enum AddressMode {
     client = 'client',
     server = 'server',
     unmanaged = 'unmanaged',
 }
 
-export interface InterfaceConfiguration {
+export interface InterfaceAddress {
     ip: string,
-    mode: InterfaceMode,
+    mode: AddressMode,
 }
 
 export interface InterfaceInfo {
@@ -16,6 +16,6 @@ export interface InterfaceInfo {
 
 export interface EthernetInterface {
     name: string,
-    configuration: InterfaceConfiguration,
+    addresses: InterfaceAddress[],
     info?: InterfaceInfo,
 }

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -354,11 +354,10 @@ class EthernetManager:
 
             valid_addresses = []
             for address in addresses:
-                # We don't care about ipv6
-                if address.family == AddressFamily.AF_INET6:
+                # We just care about IPV4 addresses
+                if not address.family == AddressFamily.AF_INET:
                     continue
 
-                # If there is no ip address the mac address will be provided (⊙＿⊙')
                 valid_ip = EthernetManager.weak_is_ip_address(address.address)
                 ip = address.address if valid_ip else "undefined"
 

--- a/core/services/cable_guy/api/manager.py
+++ b/core/services/cable_guy/api/manager.py
@@ -63,9 +63,9 @@ class EthernetManager:
                 logger.error(f"Failed loading default configuration. {error}")
             return
 
-        logger.info("Previous settings loaded:")
+        logger.info("Loading previous settings.")
         for item in self.settings.root["content"]:
-            logger.info(f"Configuration with: {item}")
+            logger.info(f"Loading following configuration: {item}.")
             try:
                 self.set_configuration(EthernetInterface(**item))
             except Exception as error:

--- a/core/services/cable_guy/api/settings.py
+++ b/core/services/cable_guy/api/settings.py
@@ -1,9 +1,9 @@
 import json
 import os
-import pprint
 from typing import Any, Dict, List
 
 import appdirs
+from loguru import logger
 
 
 class Settings:
@@ -29,7 +29,7 @@ class Settings:
             bool: False if failed
         """
         if not self.settings_exist():
-            print(f"User settings does not exist: {self.settings_file}")
+            logger.debug(f"User settings does not exist: {self.settings_file}")
             return False
 
         data = None
@@ -37,13 +37,13 @@ class Settings:
             with open(self.settings_file, encoding="utf-8") as file:
                 data = json.load(file)
                 if data["version"] != self.root["version"]:
-                    print("User settings does not match with our supported version.")
+                    logger.debug("User settings does not match with our supported version.")
                     return False
 
                 self.root = data
         except Exception as exception:
-            print(f"Failed to fetch data from file ({self.settings_file}): {exception}")
-            pprint.pprint(data)
+            logger.debug(f"Failed to fetch data from file ({self.settings_file}): {exception}")
+            logger.debug(data)
 
         return True
 
@@ -63,5 +63,5 @@ class Settings:
             os.makedirs(self.settings_path)
 
         with open(self.settings_file, "w+", encoding="utf-8") as file:
-            print(f"Updating settings file: {self.settings_file}")
+            logger.debug(f"Updating settings file: {self.settings_file}")
             json.dump(self.root, file, sort_keys=True, indent=4)

--- a/core/services/cable_guy/main.py
+++ b/core/services/cable_guy/main.py
@@ -69,11 +69,13 @@ def retrieve_interfaces() -> Any:
 @version(1, 0)
 def configure_interface(interface: EthernetInterface = Body(...)) -> Any:
     """REST API endpoint to configure a new ethernet interface or modify an existing one."""
-    if not manager.set_configuration(interface):
+    try:
+        manager.set_configuration(interface)
+    except Exception as error:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
-            detail="Could not configure ethernet interface with provided configuration.",
-        )
+            detail=f"Could not configure ethernet interface with provided configuration. {error}",
+        ) from error
 
     manager.save()
     return interface


### PR DESCRIPTION
Before this patch, cable-guy was only able to handle one address per ethernet interface. This was leading to issues like the user only being able to see one IP address on the frontend (even when the interface had multiple), which could cause some misunderstood.

With this patch, the user is now able to:
- See multiple IP addresses associated with each ethernet interface
- Add new IP addresses to a given interface
- Remove specific IP addresses from a given interface

<img width="546" alt="image" src="https://user-images.githubusercontent.com/6551040/154346502-01cc8779-f97d-44b8-998b-ec815f681faf.png">

Also, some error messages were made more clear, raises were added where necessary and logs from settings are now done with loguru.

Fix #428 