### PR TITLE
Bootstrap: Clean up apt cache after install

### DIFF
--- a/bootstrap/Dockerfile
+++ b/bootstrap/Dockerfile
@@ -1,5 +1,5 @@
 FROM debian:buster-slim
-RUN apt update && apt install -y python3 python3-setuptools python3-pip --no-install-recommends
+RUN apt update && apt install -y python3 python3-setuptools python3-pip --no-install-recommends && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY startup.json.default bootstrap/ /bootstrap/
 COPY main.py /
 RUN python3 bootstrap/setup.py install


### PR DESCRIPTION
Best practice on Docker : clean up after apt install. 
This purge 30Mb from the image. Any subsequent use of apt would need apt update anyway