### PR TITLE
core: Add support to mavlink2rest 0.11.7

### DIFF
--- a/core/frontend/src/components/health/HealthTrayMenu.vue
+++ b/core/frontend/src/components/health/HealthTrayMenu.vue
@@ -126,12 +126,12 @@ export default Vue.extend({
       return temperature_limit !== undefined
     },
     battery_voltage(): string {
-      const voltage_microvolts = mavlink_store_get(mavlink, 'SYS_STATUS.messageData.voltage_battery') as number
+      const voltage_microvolts = mavlink_store_get(mavlink, 'SYS_STATUS.messageData.message.voltage_battery') as number
       return (voltage_microvolts as number / 1000).toFixed(2)
     },
 
     battery_current(): string {
-      const current_centiampere = mavlink_store_get(mavlink, 'SYS_STATUS.messageData.current_battery') as number
+      const current_centiampere = mavlink_store_get(mavlink, 'SYS_STATUS.messageData.message.current_battery') as number
       return (current_centiampere as number / 100).toFixed(2)
     },
     disk_usage_percent(): number {

--- a/core/frontend/src/components/mavlink-inspector/MavlinkInspector.vue
+++ b/core/frontend/src/components/mavlink-inspector/MavlinkInspector.vue
@@ -113,9 +113,10 @@ class MAVLinkMessageTable {
     this.tables = {}
   }
 
-  add(message: Dictionary<any>): void {
-    const message_timed = message
+  add(mavlink_message: Dictionary<any>): void {
+    const message_timed = mavlink_message
     message_timed.timestamp = new Date()
+    const { message } = mavlink_message
     if (message.type in this.tables) {
       this.tables[message.type].push(message_timed)
       if (this.tables[message.type].length > this.size_limit) {
@@ -144,8 +145,8 @@ export default Vue.extend({
   components: {
   },
   filters: {
-    prettyPrint(message: any) {
-      return prettify(message)
+    prettyPrint(mavlink_message: any) {
+      return prettify(mavlink_message.message)
     },
   },
   data() {

--- a/core/frontend/src/types/common.ts
+++ b/core/frontend/src/types/common.ts
@@ -1,5 +1,12 @@
 /** Represents a BlueOS service, with the necessary information to identify it on the system */
 
+export type JSONValue =
+    | string
+    | number
+    | boolean
+    | { [x: string]: JSONValue }
+    | Array<JSONValue>;
+
 export interface Dictionary<T> {
   [key: string]: T;
 }

--- a/core/frontend/src/types/mavlink.ts
+++ b/core/frontend/src/types/mavlink.ts
@@ -1,6 +1,18 @@
+import { JSONValue } from '@/types/common'
+
+export interface MavlinkHeader {
+    system_id: number,
+    component_id: number,
+    sequence: number
+}
+export interface MavlinkData {
+    header: MavlinkHeader,
+    message: JSONValue
+}
+
 export interface MavlinkMessage {
     messageName: string
-    messageData: {[key: string]: {value: string|number}}
+    messageData: MavlinkData
     requestedMessageRate: number
     timestamp: Date
 }

--- a/core/tools/mavlink2rest/bootstrap.sh
+++ b/core/tools/mavlink2rest/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink2rest"
 
-VERSION=t0.11.6
+VERSION=t0.11.7
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/patrickelectric/mavlink2rest/releases/download/${VERSION}/mavlink2rest-armv7-unknown-linux-musleabihf"


### PR DESCRIPTION
- The latest version has header information of the mavlink message
- Changelog: https://github.com/patrickelectric/mavlink2rest/releases/tag/t0.11.7
- docker: patrickelectric/companion-core:m2r_ws