### PR TITLE
core: Add path for all versions available from documentation 

### DIFF
--- a/core/frontend/src/components/scanner/availableServicesTable.vue
+++ b/core/frontend/src/components/scanner/availableServicesTable.vue
@@ -6,6 +6,7 @@
         <th>Service Name</th>
         <th>Webpage</th>
         <th>API Documentation</th>
+        <th>Versions</th>
       </tr>
     </thead>
     <tbody>
@@ -32,6 +33,22 @@
         </td>
         <td v-else>
           No API documentation
+        </td>
+        <td v-if="service.versions.length !== 0">
+          <div
+            v-for="version in service.versions"
+            :key="service.port + '-' + version"
+          >
+            <a
+              text
+              :href="createWebpageUrl(service.port, version)"
+            >
+              {{ version }}
+            </a>
+          </div>
+        </td>
+        <td v-else>
+          No versions
         </td>
       </tr>
     </tbody>

--- a/core/frontend/src/types/helper.ts
+++ b/core/frontend/src/types/helper.ts
@@ -1,6 +1,6 @@
 export interface Service {
-    valid: boolean;
-    title: string;
-    documentation_url: string;
-    port: number;
-  }
+    valid: boolean
+    title: string
+    documentation_url: string
+    port: number
+}

--- a/core/frontend/src/types/helper.ts
+++ b/core/frontend/src/types/helper.ts
@@ -1,6 +1,6 @@
 export interface Service {
     valid: boolean;
     title: string;
-    documentationUrl: string;
+    documentation_url: string;
     port: number;
   }

--- a/core/frontend/src/types/helper.ts
+++ b/core/frontend/src/types/helper.ts
@@ -2,5 +2,6 @@ export interface Service {
     valid: boolean
     title: string
     documentation_url: string
+    versions: Array<string>
     port: number
 }

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -34,6 +34,7 @@ class Helper:
     LOCALSERVER_CANDIDATES = ["0.0.0.0", "::"]
 
     @staticmethod
+    @temporary_cache(timeout_seconds=60)
     def detect_service(port: int) -> ServiceInfo:
         info = ServiceInfo(valid=False, title="Unknown", documentation_url="", versions=[], port=port)
 


### PR DESCRIPTION
Available on: docker.io/patrickelectric/companion-core:versions
![image](https://user-images.githubusercontent.com/1215497/156208878-5d93e62c-7ab8-46db-b51d-47c589522f27.png)

Fix #581 