### PR TITLE
core: version-chooser: do not attempt to start bootstrap anymore

### DIFF
--- a/core/services/versionchooser/utils/chooser.py
+++ b/core/services/versionchooser/utils/chooser.py
@@ -154,10 +154,6 @@ class VersionChooser:
                 startup_file.write(json.dumps(data, indent=2))
                 startup_file.truncate()
 
-                logging.info("Starting bootstrap...")
-                bootstrap = await self.client.containers.get("companion-bootstrap")  # type: ignore
-                await bootstrap.start()
-
                 logging.info("Stopping core...")
                 core = await self.client.containers.get("companion-core")  # type: ignore
                 if core:


### PR DESCRIPTION
it is started every boot and no longer exits.

This fixes an issue in the new images where version chooser tried to start companion-bootstrap but it doesn't exist (we use blueos-bootstrap instead)