### PR TITLE
core: ardupilotmanager: bump default navigator firmware to 4.1.0-beta3

### DIFF
--- a/core/services/ardupilot_manager/setup.py
+++ b/core/services/ardupilot_manager/setup.py
@@ -42,7 +42,7 @@ static_files = [
         defaults_folder,
         "ardupilot_navigator",
         # TODO: use "https://firmware.ardupilot.org/Sub/beta/navigator/ardusub" instead
-        "https://s3.us-west-1.amazonaws.com/ardusub.bluerobotics.com/test-builds/ardusub-410-beta2-navigator-r5",
+        "https://s3.us-west-1.amazonaws.com/ardusub.bluerobotics.com/test-builds/ardusub-410-beta3-navigator-r5",
     ),
     StaticFile(defaults_folder, "ardupilot_pixhawk1", "https://firmware.ardupilot.org/Sub/latest/Pixhawk1/ardusub.apj"),
 ]


### PR DESCRIPTION
Beta3 includes default streamrates and default settings for lights and camera tilt mount pins