### PR TITLE
core: ardupilot-manager: Support Pixhawk4 (+ other improvements)

### DIFF
--- a/core/frontend/src/components/autopilot/BoardChangeDialog.vue
+++ b/core/frontend/src/components/autopilot/BoardChangeDialog.vue
@@ -1,0 +1,114 @@
+<template>
+  <v-dialog
+    width="500"
+    :value="show"
+    @input="showDialog"
+  >
+    <v-card>
+      <v-card-title>
+        Change running board
+      </v-card-title>
+
+      <v-card-text class="d-flex flex-column">
+        <v-form
+          ref="form"
+          lazy-validation
+        >
+          <v-select
+            v-model="selected_board"
+            :items="board_options"
+            label="Available boards"
+            required
+          />
+
+          <v-btn
+            color="success"
+            class="mr-4"
+            @click="changeBoard"
+          >
+            Set
+          </v-btn>
+        </v-form>
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+import autopilot from '@/store/autopilot_manager'
+import notifications from '@/store/notifications'
+import { FlightController } from '@/types/autopilot'
+import { autopilot_service } from '@/types/frontend_services'
+import { VForm } from '@/types/vuetify'
+import back_axios from '@/utils/api'
+
+export default Vue.extend({
+  name: 'ConnectionDialog',
+  model: {
+    prop: 'show',
+    event: 'change',
+  },
+  props: {
+    show: {
+      type: Boolean,
+      default: false,
+    },
+  },
+
+  data() {
+    return {
+      selected_board: null,
+    }
+  },
+  computed: {
+    board_options(): {value: FlightController, text: string}[] {
+      return this.available_boards.map(
+        (board) => ({ value: board, text: board.name }),
+      )
+    },
+    available_boards(): FlightController[] {
+      return autopilot.available_boards
+    },
+    form(): VForm {
+      return this.$refs.form as VForm
+    },
+  },
+  methods: {
+    async changeBoard(): Promise<boolean> {
+      if (!this.form.validate()) {
+        return false
+      }
+      this.showDialog(false)
+      autopilot.setRestarting(true)
+
+      await back_axios({
+        method: 'post',
+        url: `${autopilot.API_URL}/board`,
+        data: this.selected_board,
+        timeout: 10000,
+      })
+        .then(() => {
+          this.form.reset()
+        })
+        .catch((error) => {
+          const { message } = error
+          notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_BOARD_CHANGE_FAIL', message })
+          return false
+        })
+        .finally(() => {
+          autopilot.setRestarting(false)
+        })
+      return true
+    },
+
+    showDialog(state: boolean) {
+      this.$emit('change', state)
+    },
+  },
+})
+</script>
+
+<style>
+</style>

--- a/core/frontend/src/store/autopilot_manager.ts
+++ b/core/frontend/src/store/autopilot_manager.ts
@@ -3,7 +3,7 @@ import {
 } from 'vuex-module-decorators'
 
 import store from '@/store'
-import { AutopilotEndpoint, Platform } from '@/types/autopilot'
+import { AutopilotEndpoint, FlightController } from '@/types/autopilot'
 
 @Module({
   dynamic: true,
@@ -16,9 +16,13 @@ class AutopilotManagerStore extends VuexModule {
 
   available_endpoints: AutopilotEndpoint[] = []
 
-  current_platform: Platform = Platform.Undefined
+  available_boards: FlightController[] = []
+
+  current_board: FlightController | null = null
 
   updating_endpoints = true
+
+  updating_boards = true
 
   restarting = false
 
@@ -33,14 +37,20 @@ class AutopilotManagerStore extends VuexModule {
   }
 
   @Mutation
-  setCurrentPlatform(platform: Platform): void {
-    this.current_platform = platform
+  setCurrentBoard(board: FlightController | null): void {
+    this.current_board = board
   }
 
   @Mutation
   setAvailableEndpoints(available_endpoints: AutopilotEndpoint[]): void {
     this.available_endpoints = available_endpoints
     this.updating_endpoints = false
+  }
+
+  @Mutation
+  setAvailableBoards(available_boards: FlightController[]): void {
+    this.available_boards = available_boards
+    this.updating_boards = false
   }
 }
 

--- a/core/frontend/src/types/autopilot.ts
+++ b/core/frontend/src/types/autopilot.ts
@@ -15,7 +15,6 @@ export enum Platform {
   Navigator = 'navigator',
   SITL_X86 = 'SITL_x86_64_linux_gnu',
   SITL_ARM = 'SITL_arm_linux_gnueabihf',
-  Undefined = 'Undefined',
 }
 
 export enum EndpointType {

--- a/core/frontend/src/types/autopilot.ts
+++ b/core/frontend/src/types/autopilot.ts
@@ -45,3 +45,10 @@ export interface AutopilotEndpoint {
     protected: boolean
     enabled: boolean
 }
+
+export interface FlightController {
+  name: string
+  manufacturer: string
+  platform: Platform
+  path: string
+}

--- a/core/frontend/src/types/autopilot.ts
+++ b/core/frontend/src/types/autopilot.ts
@@ -13,6 +13,7 @@ export enum Vehicle {
 export enum Platform {
   Pixhawk1 = 'Pixhawk1',
   Pixhawk4 = 'Pixhawk4',
+  GenericSerial = 'GenericSerial',
   Navigator = 'navigator',
   SITL_X86 = 'SITL_x86_64_linux_gnu',
   SITL_ARM = 'SITL_arm_linux_gnueabihf',

--- a/core/frontend/src/types/autopilot.ts
+++ b/core/frontend/src/types/autopilot.ts
@@ -12,6 +12,7 @@ export enum Vehicle {
 
 export enum Platform {
   Pixhawk1 = 'Pixhawk1',
+  Pixhawk4 = 'Pixhawk4',
   Navigator = 'navigator',
   SITL_X86 = 'SITL_x86_64_linux_gnu',
   SITL_ARM = 'SITL_arm_linux_gnueabihf',

--- a/core/libs/commonwealth/commonwealth/utils/general.py
+++ b/core/libs/commonwealth/commonwealth/utils/general.py
@@ -1,0 +1,5 @@
+import os
+
+
+def is_running_as_root() -> bool:
+    return os.geteuid() == 0

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -84,7 +84,7 @@ class ArduPilotManager(metaclass=Singleton):
         await self.mavlink_manager.auto_restart_router()
 
     def run_with_board(self) -> None:
-        if not self.start_board(BoardDetector.detect()):
+        if not self.start_board(BoardDetector.detect(include_sitl=False)):
             logger.warning("Flight controller board not detected.")
 
     @staticmethod

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -1,5 +1,4 @@
 import asyncio
-import os
 import pathlib
 import subprocess
 from copy import deepcopy
@@ -86,11 +85,6 @@ class ArduPilotManager(metaclass=Singleton):
     def run_with_board(self) -> None:
         if not self.start_board(BoardDetector.detect(include_sitl=False)):
             logger.warning("Flight controller board not detected.")
-
-    @staticmethod
-    def check_running_as_root() -> None:
-        if os.geteuid() != 0:
-            raise RuntimeError("ArduPilot manager needs to run with root privilege.")
 
     @property
     def current_platform(self) -> Optional[Platform]:

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -307,8 +307,12 @@ class ArduPilotManager(metaclass=Singleton):
         """Return list of all Ardupilot process running on system."""
 
         def is_ardupilot_process(process: psutil.Process) -> bool:
-            """Checks if given process is using Ardupilot's firmware file for current platform."""
-            return str(self.current_firmware_path()) in " ".join(process.cmdline())
+            """Checks if given process is using a Ardupilot's firmware file, for any known platform."""
+            for platform in Platform:
+                firmware_path = self.firmware_manager.firmware_path(platform)
+                if str(firmware_path) in " ".join(process.cmdline()):
+                    return True
+            return False
 
         return list(filter(is_ardupilot_process, psutil.process_iter()))
 

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -117,8 +117,9 @@ class ArduPilotManager(metaclass=Singleton):
         self.current_platform = board.platform
         if not self.firmware_manager.is_firmware_installed(self.current_platform):
             if board.platform == Platform.Navigator:
-                self.install_firmware_from_file(
-                    pathlib.Path("/root/companion-files/ardupilot-manager/default/ardupilot_navigator")
+                self.firmware_manager.install_firmware_from_file(
+                    pathlib.Path("/root/companion-files/ardupilot-manager/default/ardupilot_navigator"),
+                    board.platform,
                 )
 
         self.firmware_manager.validate_firmware(self.current_firmware_path(), self.current_platform)
@@ -427,14 +428,14 @@ class ArduPilotManager(metaclass=Singleton):
         self._save_current_endpoints()
         self.mavlink_manager.restart()
 
-    def get_available_firmwares(self, vehicle: Vehicle) -> List[Firmware]:
-        return self.firmware_manager.get_available_firmwares(vehicle, self.current_platform)
+    def get_available_firmwares(self, vehicle: Vehicle, platform: Platform) -> List[Firmware]:
+        return self.firmware_manager.get_available_firmwares(vehicle, platform)
 
-    def install_firmware_from_file(self, firmware_path: pathlib.Path) -> None:
-        self.firmware_manager.install_firmware_from_file(firmware_path, self.current_platform)
+    def install_firmware_from_file(self, firmware_path: pathlib.Path, platform: Platform) -> None:
+        self.firmware_manager.install_firmware_from_file(firmware_path, platform)
 
-    def install_firmware_from_url(self, url: str) -> None:
-        self.firmware_manager.install_firmware_from_url(url, self.current_platform)
+    def install_firmware_from_url(self, url: str, platform: Platform) -> None:
+        self.firmware_manager.install_firmware_from_url(url, platform)
 
-    def restore_default_firmware(self) -> None:
-        self.firmware_manager.restore_default_firmware(self.current_platform)
+    def restore_default_firmware(self, platform: Platform) -> None:
+        self.firmware_manager.restore_default_firmware(platform)

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -14,6 +14,7 @@ from exceptions import (
     ArdupilotProcessKillFail,
     EndpointAlreadyExists,
     MavlinkRouterStartFail,
+    NoPreferredBoardSet,
 )
 from firmware.FirmwareManagement import FirmwareManager
 from flight_controller_detector.Detector import Detector as BoardDetector
@@ -257,6 +258,35 @@ class ArduPilotManager(metaclass=Singleton):
         self.mavlink_manager.set_master_endpoint(device)
         self.mavlink_manager.start()
 
+    def set_preferred_board(self, board: FlightController) -> None:
+        logger.info(f"Setting {board.name} as preferred flight-controller.")
+        self.configuration["preferred_board"] = board.dict(exclude={"path"})
+        self.settings.save(self.configuration)
+
+    def get_preferred_board(self) -> FlightController:
+        preferred_board = self.configuration.get("preferred_board")
+        if not preferred_board:
+            raise NoPreferredBoardSet("Preferred board not set yet.")
+        return FlightController(**preferred_board)
+
+    def get_board_to_be_used(self, boards: List[FlightController]) -> FlightController:
+        """Check if preferred board exists and is connected. If so, use it, otherwise, choose by priority."""
+        try:
+            preferred_board = self.get_preferred_board()
+            logger.debug(f"Preferred flight-controller is {preferred_board.name}.")
+            for board in boards:
+                # Compare connected boards with saved board, excluding path (which can change between sessions)
+                if preferred_board.dict(exclude={"path"}).items() <= board.dict().items():
+                    return board
+            logger.debug(f"Flight-controller {preferred_board.name} not connected.")
+        except NoPreferredBoardSet as error:
+            logger.warning(error)
+
+        boards.sort(key=lambda board: board.platform)
+        preferred_board = boards[0]
+        self.set_preferred_board(preferred_board)
+        return preferred_board
+
     def start_board(self, boards: List[FlightController]) -> bool:
         if not boards:
             return False
@@ -264,11 +294,9 @@ class ArduPilotManager(metaclass=Singleton):
         if len(boards) > 1:
             logger.warning(f"More than a single board detected: {boards}")
 
-        # Sort by priority
-        boards.sort(key=lambda flight_controller: flight_controller.platform)
+        flight_controller = self.get_board_to_be_used(boards)
 
-        flight_controller = boards[0]
-        logger.info(f"Board in use: {flight_controller}.")
+        logger.info(f"Using {flight_controller.name} flight-controller.")
 
         if flight_controller.platform in [Platform.Navigator]:
             self.start_navigator(flight_controller)

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -259,8 +259,7 @@ class ArduPilotManager(metaclass=Singleton):
                 pass
             except Exception as error:
                 logger.warning(str(error))
-        self.mavlink_manager.set_master_endpoint(device)
-        self.mavlink_manager.start()
+        self.mavlink_manager.start(device)
 
     def set_preferred_board(self, board: FlightController) -> None:
         logger.info(f"Setting {board.name} as preferred flight-controller.")

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -112,11 +112,11 @@ class ArduPilotManager(metaclass=Singleton):
 
     def start_navigator(self, board: FlightController) -> None:
         self.current_board = board
-        if not self.firmware_manager.is_firmware_installed(self.current_board.platform):
+        if not self.firmware_manager.is_firmware_installed(self.current_board):
             if board.platform == Platform.Navigator:
                 self.firmware_manager.install_firmware_from_file(
                     pathlib.Path("/root/companion-files/ardupilot-manager/default/ardupilot_navigator"),
-                    board.platform,
+                    board,
                 )
 
         self.firmware_manager.validate_firmware(self.current_firmware_path(), self.current_board.platform)
@@ -167,8 +167,8 @@ class ArduPilotManager(metaclass=Singleton):
 
     def run_with_sitl(self, frame: SITLFrame = SITLFrame.VECTORED) -> None:
         self.current_board = BoardDetector.detect_sitl()
-        if not self.firmware_manager.is_firmware_installed(self.current_board.platform):
-            self.firmware_manager.install_firmware_from_params(Vehicle.Sub, self.current_board.platform)
+        if not self.firmware_manager.is_firmware_installed(self.current_board):
+            self.firmware_manager.install_firmware_from_params(Vehicle.Sub, self.current_board)
         if frame == SITLFrame.UNDEFINED:
             frame = SITLFrame.VECTORED
             logger.warning(f"SITL frame is undefined. Setting {frame} as current frame.")
@@ -427,11 +427,11 @@ class ArduPilotManager(metaclass=Singleton):
     def get_available_firmwares(self, vehicle: Vehicle, platform: Platform) -> List[Firmware]:
         return self.firmware_manager.get_available_firmwares(vehicle, platform)
 
-    def install_firmware_from_file(self, firmware_path: pathlib.Path, platform: Platform) -> None:
-        self.firmware_manager.install_firmware_from_file(firmware_path, platform)
+    def install_firmware_from_file(self, firmware_path: pathlib.Path, board: FlightController) -> None:
+        self.firmware_manager.install_firmware_from_file(firmware_path, board)
 
-    def install_firmware_from_url(self, url: str, platform: Platform) -> None:
-        self.firmware_manager.install_firmware_from_url(url, platform)
+    def install_firmware_from_url(self, url: str, board: FlightController) -> None:
+        self.firmware_manager.install_firmware_from_url(url, board)
 
-    def restore_default_firmware(self, platform: Platform) -> None:
-        self.firmware_manager.restore_default_firmware(platform)
+    def restore_default_firmware(self, board: FlightController) -> None:
+        self.firmware_manager.restore_default_firmware(board)

--- a/core/services/ardupilot_manager/exceptions.py
+++ b/core/services/ardupilot_manager/exceptions.py
@@ -93,3 +93,7 @@ class DuplicateEndpointName(ValueError):
 
 class EndpointDontExist(ValueError):
     """Given Mavlink endpoint do not exist."""
+
+
+class NoPreferredBoardSet(RuntimeError):
+    """No preferred board is set yet."""

--- a/core/services/ardupilot_manager/firmware/FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware/FirmwareDownload.py
@@ -34,6 +34,7 @@ class FirmwareDownloader:
     _supported_firmware_formats = {
         Platform.SITL: FirmwareFormat.ELF,
         Platform.Pixhawk1: FirmwareFormat.APJ,
+        Platform.Pixhawk4: FirmwareFormat.APJ,
         Platform.Navigator: FirmwareFormat.ELF,
     }
 

--- a/core/services/ardupilot_manager/firmware/FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware/FirmwareDownload.py
@@ -21,7 +21,7 @@ from exceptions import (
     NoCandidate,
     NoVersionAvailable,
 )
-from typedefs import FirmwareFormat, Platform, Vehicle
+from typedefs import FirmwareFormat, Platform, PlatformType, Vehicle
 
 # TODO: This should be not necessary
 # Disable SSL verification
@@ -32,10 +32,9 @@ if not os.environ.get("PYTHONHTTPSVERIFY", "") and getattr(ssl, "_create_unverif
 class FirmwareDownloader:
     _manifest_remote = "https://firmware.ardupilot.org/manifest.json.gz"
     _supported_firmware_formats = {
-        Platform.SITL: FirmwareFormat.ELF,
-        Platform.Pixhawk1: FirmwareFormat.APJ,
-        Platform.Pixhawk4: FirmwareFormat.APJ,
-        Platform.Navigator: FirmwareFormat.ELF,
+        PlatformType.SITL: FirmwareFormat.ELF,
+        PlatformType.Serial: FirmwareFormat.APJ,
+        PlatformType.Linux: FirmwareFormat.ELF,
     }
 
     def __init__(self) -> None:
@@ -150,7 +149,7 @@ class FirmwareDownloader:
         items = self._find_version_item(vehicletype=vehicle.value, platform=platform.value)
 
         for item in items:
-            if item["format"] == FirmwareDownloader._supported_firmware_formats[platform]:
+            if item["format"] == FirmwareDownloader._supported_firmware_formats[platform.type]:
                 available_versions.append(item["mav-firmware-version-type"])
 
         return available_versions
@@ -176,7 +175,7 @@ class FirmwareDownloader:
         if version and version not in versions:
             raise NoVersionAvailable(f"Version {version} was not found for {platform}/{vehicle}.")
 
-        firmware_format = FirmwareDownloader._supported_firmware_formats[platform]
+        firmware_format = FirmwareDownloader._supported_firmware_formats[platform.type]
 
         # Autodetect the latest supported version.
         # For .apj firmwares (e.g. Pixhawk), we use the latest STABLE version while for the others (e.g. SITL and

--- a/core/services/ardupilot_manager/firmware/FirmwareInstall.py
+++ b/core/services/ardupilot_manager/firmware/FirmwareInstall.py
@@ -100,7 +100,7 @@ class FirmwareInstaller:
     @staticmethod
     def validate_firmware(firmware_path: pathlib.Path, platform: Platform) -> None:
         """Check if given firmware is valid for given platform."""
-        firmware_format = FirmwareDownloader._supported_firmware_formats[platform]
+        firmware_format = FirmwareDownloader._supported_firmware_formats[platform.type]
 
         if firmware_format == FirmwareFormat.APJ:
             FirmwareInstaller._validate_apj(firmware_path, platform)
@@ -133,7 +133,7 @@ class FirmwareInstaller:
         if not new_firmware_path.is_file():
             raise InvalidFirmwareFile("Given path is not a valid file.")
 
-        firmware_format = FirmwareDownloader._supported_firmware_formats[board.platform]
+        firmware_format = FirmwareDownloader._supported_firmware_formats[board.platform.type]
         if firmware_format == FirmwareFormat.ELF:
             self.add_run_permission(new_firmware_path)
 

--- a/core/services/ardupilot_manager/firmware/FirmwareInstall.py
+++ b/core/services/ardupilot_manager/firmware/FirmwareInstall.py
@@ -18,6 +18,7 @@ from typedefs import FirmwareFormat, FlightController, Platform, PlatformType
 def get_board_id(platform: Platform) -> int:
     ardupilot_board_ids = {
         Platform.Pixhawk1: 9,
+        Platform.Pixhawk4: 50,
     }
     return ardupilot_board_ids.get(platform, -1)
 

--- a/core/services/ardupilot_manager/firmware/FirmwareInstall.py
+++ b/core/services/ardupilot_manager/firmware/FirmwareInstall.py
@@ -9,12 +9,7 @@ from typing import Optional, Union
 from ardupilot_fw_decoder import BoardSubType, BoardType, Decoder
 from elftools.elf.elffile import ELFFile
 
-from exceptions import (
-    FirmwareInstallFail,
-    InvalidFirmwareFile,
-    UndefinedPlatform,
-    UnsupportedPlatform,
-)
+from exceptions import FirmwareInstallFail, InvalidFirmwareFile, UnsupportedPlatform
 from firmware.FirmwareDownload import FirmwareDownloader
 from firmware.FirmwareUpload import FirmwareUploader
 from typedefs import FirmwareFormat, Platform
@@ -104,9 +99,6 @@ class FirmwareInstaller:
     @staticmethod
     def validate_firmware(firmware_path: pathlib.Path, platform: Platform) -> None:
         """Check if given firmware is valid for given platform."""
-        if platform == Platform.Undefined:
-            raise UndefinedPlatform("Platform is undefined. Cannot validate firmware.")
-
         firmware_format = FirmwareDownloader._supported_firmware_formats[platform]
 
         if firmware_format == FirmwareFormat.APJ:
@@ -134,9 +126,6 @@ class FirmwareInstaller:
         self, new_firmware_path: pathlib.Path, platform: Platform, firmware_dest_path: Optional[pathlib.Path] = None
     ) -> None:
         """Install given firmware."""
-        if platform == Platform.Undefined:
-            raise UndefinedPlatform("Platform is undefined. Cannot install firmware.")
-
         if not new_firmware_path.is_file():
             raise InvalidFirmwareFile("Given path is not a valid file.")
 

--- a/core/services/ardupilot_manager/firmware/FirmwareManagement.py
+++ b/core/services/ardupilot_manager/firmware/FirmwareManagement.py
@@ -7,7 +7,6 @@ from exceptions import (
     FirmwareInstallFail,
     NoDefaultFirmwareAvailable,
     NoVersionAvailable,
-    UndefinedPlatform,
     UnsupportedPlatform,
 )
 from firmware.FirmwareDownload import FirmwareDownloader
@@ -41,9 +40,6 @@ class FirmwareManager:
 
     def is_firmware_installed(self, platform: Platform) -> bool:
         """Check if firmware for given platform is installed."""
-        if platform == Platform.Undefined:
-            raise UndefinedPlatform("Platform is undefined. Cannot verify if firmware is installed.")
-
         if platform == Platform.Pixhawk1:
             # Assumes for now that a Pixhawk always has a firmware installed, which is true most of the time
             # TODO: Validate if properly. The uploader tool seems capable of doing this.

--- a/core/services/ardupilot_manager/firmware/FirmwareManagement.py
+++ b/core/services/ardupilot_manager/firmware/FirmwareManagement.py
@@ -52,7 +52,7 @@ class FirmwareManager:
             # TODO: Validate if properly. The uploader tool seems capable of doing this.
             return True
 
-        firmware_format = FirmwareDownloader._supported_firmware_formats[board.platform]
+        firmware_format = FirmwareDownloader._supported_firmware_formats[board.platform.type]
         if firmware_format == FirmwareFormat.ELF:
             return pathlib.Path.is_file(self.firmware_path(board.platform))
 

--- a/core/services/ardupilot_manager/firmware/FirmwareManagement.py
+++ b/core/services/ardupilot_manager/firmware/FirmwareManagement.py
@@ -76,7 +76,7 @@ class FirmwareManager:
 
     def install_firmware_from_file(self, new_firmware_path: pathlib.Path, board: FlightController) -> None:
         try:
-            if board.platform == Platform.Pixhawk1:
+            if board.type == PlatformType.Serial:
                 self.firmware_installer.install_firmware(new_firmware_path, board)
             else:
                 self.firmware_installer.install_firmware(new_firmware_path, board, self.firmware_path(board.platform))

--- a/core/services/ardupilot_manager/firmware/FirmwareUpload.py
+++ b/core/services/ardupilot_manager/firmware/FirmwareUpload.py
@@ -78,3 +78,5 @@ class FirmwareUploader:
             raise FirmwareUploadFail(f"Unable to upload firmware: {error}") from error
         finally:
             timer.cancel()
+            # Give some time for the board to reboot (preventing fail reconnecting to it)
+            time.sleep(10)

--- a/core/services/ardupilot_manager/firmware/test_FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware/test_FirmwareDownload.py
@@ -43,6 +43,8 @@ def test_firmware_download() -> None:
 
     assert firmware_download.download(Vehicle.Sub, Platform.Pixhawk1), "Failed to download latest valid firmware file."
 
+    assert firmware_download.download(Vehicle.Sub, Platform.Pixhawk4), "Failed to download latest valid firmware file."
+
     assert firmware_download.download(Vehicle.Sub, Platform.SITL), "Failed to download SITL."
 
     # It'll fail if running in an arch different of ARM

--- a/core/services/ardupilot_manager/firmware/test_FirmwareInstall.py
+++ b/core/services/ardupilot_manager/firmware/test_FirmwareInstall.py
@@ -5,7 +5,7 @@ import pytest
 from exceptions import InvalidFirmwareFile
 from firmware.FirmwareDownload import FirmwareDownloader
 from firmware.FirmwareInstall import FirmwareInstaller
-from typedefs import Platform, Vehicle
+from typedefs import FlightController, Platform, Vehicle
 
 
 def test_firmware_validation() -> None:
@@ -27,4 +27,5 @@ def test_firmware_validation() -> None:
 
     # Install SITL firmware
     temporary_file = downloader.download(Vehicle.Sub, Platform.SITL, version="DEV")
-    installer.install_firmware(temporary_file, Platform.SITL, pathlib.Path(f"{temporary_file}_dest"))
+    board = FlightController(name="SITL", manufacturer="ArduPilot Team", platform=Platform.SITL)
+    installer.install_firmware(temporary_file, board, pathlib.Path(f"{temporary_file}_dest"))

--- a/core/services/ardupilot_manager/firmware/test_FirmwareInstall.py
+++ b/core/services/ardupilot_manager/firmware/test_FirmwareInstall.py
@@ -2,7 +2,7 @@ import pathlib
 
 import pytest
 
-from exceptions import InvalidFirmwareFile, UndefinedPlatform
+from exceptions import InvalidFirmwareFile
 from firmware.FirmwareDownload import FirmwareDownloader
 from firmware.FirmwareInstall import FirmwareInstaller
 from typedefs import Platform, Vehicle
@@ -19,10 +19,6 @@ def test_firmware_validation() -> None:
     # New SITL firmwares should always work
     temporary_file = downloader.download(Vehicle.Sub, Platform.SITL, version="DEV")
     installer.validate_firmware(temporary_file, Platform.SITL)
-
-    # Raise when validating for Undefined platform
-    with pytest.raises(UndefinedPlatform):
-        installer.validate_firmware(pathlib.Path(""), Platform.Undefined)
 
     # Raise when validating Navigator firmwares (as test platform is x86)
     temporary_file = downloader.download(Vehicle.Sub, Platform.Navigator)

--- a/core/services/ardupilot_manager/firmware/test_FirmwareInstall.py
+++ b/core/services/ardupilot_manager/firmware/test_FirmwareInstall.py
@@ -12,9 +12,12 @@ def test_firmware_validation() -> None:
     downloader = FirmwareDownloader()
     installer = FirmwareInstaller()
 
-    # Pixhawk1 APJ firmwares should always work
+    # Pixhawk1 and Pixhawk4 APJ firmwares should always work
     temporary_file = downloader.download(Vehicle.Sub, Platform.Pixhawk1)
     installer.validate_firmware(temporary_file, Platform.Pixhawk1)
+
+    temporary_file = downloader.download(Vehicle.Sub, Platform.Pixhawk4)
+    installer.validate_firmware(temporary_file, Platform.Pixhawk4)
 
     # New SITL firmwares should always work
     temporary_file = downloader.download(Vehicle.Sub, Platform.SITL, version="DEV")

--- a/core/services/ardupilot_manager/flight_controller_detector/Detector.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/Detector.py
@@ -59,6 +59,8 @@ class Detector:
             return Platform.Pixhawk1
         if port.product in ["Pixhawk4", "PX4 FMU v5.x"]:
             return Platform.Pixhawk4
+        if port.manufacturer in ["ArduPilot", "3D Robotics"] and (port.product and not "BL" in port.product):
+            return Platform.GenericSerial
         return None
 
     @staticmethod

--- a/core/services/ardupilot_manager/flight_controller_detector/Detector.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/Detector.py
@@ -55,9 +55,9 @@ class Detector:
 
     @staticmethod
     def detect_serial_platform(port: SysFS) -> Optional[Platform]:
-        if port.manufacturer == "ArduPilot":
+        if port.product in ["Pixhawk1", "PX4 FMU v2.x"]:
             return Platform.Pixhawk1
-        if port.manufacturer == "3D Robotics" and "PX4" in port.product:
+        if port.product in ["Pixhawk4", "PX4 FMU v5.x"]:
             return Platform.Pixhawk4
         return None
 

--- a/core/services/ardupilot_manager/flight_controller_detector/Detector.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/Detector.py
@@ -70,6 +70,12 @@ class Detector:
         Returns:
             List[FlightController]: List with connected serial flight controller.
         """
+        sorted_serial_ports = sorted(comports(), key=lambda port: port.name)  # type: ignore
+        unique_serial_devices: List[SysFS] = []
+        for port in sorted_serial_ports:
+            # usb_device_path property will be the same for two serial connections using the same USB port
+            if port.usb_device_path not in [device.usb_device_path for device in unique_serial_devices]:
+                unique_serial_devices.append(port)
         return [
             FlightController(
                 name=port.product or port.name,
@@ -77,7 +83,7 @@ class Detector:
                 platform=Detector.detect_serial_platform(port),
                 path=port.device,
             )
-            for port in comports()
+            for port in unique_serial_devices
             if Detector.detect_serial_platform(port) is not None
         ]
 

--- a/core/services/ardupilot_manager/flight_controller_detector/Detector.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/Detector.py
@@ -54,12 +54,16 @@ class Detector:
         return None
 
     @staticmethod
-    def is_valid_serial_controller(port: SysFS) -> bool:
-        return port.manufacturer == "ArduPilot" or (port.manufacturer == "3D Robotics" and "PX4" in port.product)
+    def detect_serial_platform(port: SysFS) -> Optional[Platform]:
+        if port.manufacturer == "ArduPilot":
+            return Platform.Pixhawk1
+        if port.manufacturer == "3D Robotics" and "PX4" in port.product:
+            return Platform.Pixhawk4
+        return None
 
     @staticmethod
     def detect_serial_flight_controllers() -> List[FlightController]:
-        """Check if a Pixhawk1 or any other valid serial flight controller is connected.
+        """Check if a Pixhawk1 or a Pixhawk4 is connected.
 
         Returns:
             List[FlightController]: List with connected serial flight controller.
@@ -68,11 +72,11 @@ class Detector:
             FlightController(
                 name=port.product or port.name,
                 manufacturer=port.manufacturer,
-                platform=Platform.Pixhawk1,
+                platform=Detector.detect_serial_platform(port),
                 path=port.device,
             )
             for port in comports()
-            if Detector.is_valid_serial_controller(port)
+            if Detector.detect_serial_platform(port) is not None
         ]
 
     @staticmethod

--- a/core/services/ardupilot_manager/flight_controller_detector/Detector.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/Detector.py
@@ -75,8 +75,12 @@ class Detector:
             if Detector.is_valid_serial_controller(port)
         ]
 
+    @staticmethod
+    def detect_sitl() -> FlightController:
+        return FlightController(name="SITL", manufacturer="ArduPilot Team", platform=Platform.SITL)
+
     @classmethod
-    def detect(cls) -> List[FlightController]:
+    def detect(cls, include_sitl: bool = True) -> List[FlightController]:
         """Return a list of available flight controllers
 
         Returns:
@@ -91,5 +95,8 @@ class Detector:
             available.append(navigator)
 
         available.extend(cls().detect_serial_flight_controllers())
+
+        if include_sitl:
+            available.append(Detector.detect_sitl())
 
         return available

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -88,7 +88,7 @@ def update_endpoints(endpoints: Set[Endpoint] = Body(...)) -> Any:
 @version(1, 0)
 def get_available_firmwares(response: Response, vehicle: Vehicle) -> Any:
     try:
-        return autopilot.get_available_firmwares(vehicle)
+        return autopilot.get_available_firmwares(vehicle, autopilot.current_platform)
     except Exception as error:
         response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
         return {"message": f"{error}"}
@@ -99,7 +99,7 @@ def get_available_firmwares(response: Response, vehicle: Vehicle) -> Any:
 async def install_firmware_from_url(response: Response, url: str) -> Any:
     try:
         await autopilot.kill_ardupilot()
-        autopilot.install_firmware_from_url(url)
+        autopilot.install_firmware_from_url(url, autopilot.current_platform)
     except Exception as error:
         response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
         return {"message": f"{error}"}
@@ -115,7 +115,7 @@ async def install_firmware_from_file(response: Response, binary: UploadFile = Fi
         with open(custom_firmware, "wb") as buffer:
             shutil.copyfileobj(binary.file, buffer)
         await autopilot.kill_ardupilot()
-        autopilot.install_firmware_from_file(custom_firmware)
+        autopilot.install_firmware_from_file(custom_firmware, autopilot.current_platform)
         os.remove(custom_firmware)
     except InvalidFirmwareFile as error:
         response.status_code = status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
@@ -197,7 +197,7 @@ async def stop(response: Response) -> Any:
 async def restore_default_firmware(response: Response) -> Any:
     try:
         await autopilot.kill_ardupilot()
-        autopilot.restore_default_firmware()
+        autopilot.restore_default_firmware(autopilot.current_platform)
     except Exception as error:
         response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
         return {"message": f"{error}"}

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -21,7 +21,7 @@ from exceptions import InvalidFirmwareFile
 from flight_controller_detector.Detector import Detector as BoardDetector
 from mavlink_proxy.Endpoint import Endpoint
 from settings import SERVICE_NAME
-from typedefs import Firmware, FlightController, Platform, SITLFrame, Vehicle
+from typedefs import Firmware, FlightController, SITLFrame, Vehicle
 
 FRONTEND_FOLDER = Path.joinpath(Path(__file__).parent.absolute(), "frontend")
 
@@ -136,13 +136,11 @@ async def install_firmware_from_file(response: Response, binary: UploadFile = Fi
         await autopilot.start_ardupilot()
 
 
-@app.get("/platform", response_model=Platform, summary="Check what is the current running platform.")
+@app.get("/board", response_model=FlightController, summary="Check what is the current running board.")
 @version(1, 0)
-def platform(response: Response) -> Any:
+def get_board(response: Response) -> Any:
     try:
-        if not autopilot.current_board:
-            raise RuntimeError("Cannot fetch current platform as there's no board running.")
-        return autopilot.current_board.platform
+        return autopilot.current_board
     except Exception as error:
         response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
         return {"message": f"{error}"}

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -105,7 +105,7 @@ async def install_firmware_from_url(response: Response, url: str) -> Any:
         if not autopilot.current_board:
             raise RuntimeError("Cannot install firmware as there's no board running.")
         await autopilot.kill_ardupilot()
-        autopilot.install_firmware_from_url(url, autopilot.current_board.platform)
+        autopilot.install_firmware_from_url(url, autopilot.current_board)
     except Exception as error:
         response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
         return {"message": f"{error}"}
@@ -123,7 +123,7 @@ async def install_firmware_from_file(response: Response, binary: UploadFile = Fi
         with open(custom_firmware, "wb") as buffer:
             shutil.copyfileobj(binary.file, buffer)
         await autopilot.kill_ardupilot()
-        autopilot.install_firmware_from_file(custom_firmware, autopilot.current_board.platform)
+        autopilot.install_firmware_from_file(custom_firmware, autopilot.current_board)
         os.remove(custom_firmware)
     except InvalidFirmwareFile as error:
         response.status_code = status.HTTP_415_UNSUPPORTED_MEDIA_TYPE
@@ -209,7 +209,7 @@ async def restore_default_firmware(response: Response) -> Any:
         if not autopilot.current_board:
             raise RuntimeError("Cannot restore firmware as there's no board running.")
         await autopilot.kill_ardupilot()
-        autopilot.restore_default_firmware(autopilot.current_board.platform)
+        autopilot.restore_default_firmware(autopilot.current_board)
     except Exception as error:
         response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
         return {"message": f"{error}"}

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -146,7 +146,7 @@ async def set_platform(response: Response, use_sitl: bool, sitl_frame: SITLFrame
             autopilot.current_platform = Platform.SITL
             autopilot.current_sitl_frame = sitl_frame
         else:
-            autopilot.current_platform = Platform.Undefined
+            autopilot.current_platform = None
         logger.debug("Restarting ardupilot...")
         await autopilot.kill_ardupilot()
         await autopilot.start_ardupilot()

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Set
 
 from commonwealth.utils.apis import PrettyJSONResponse
+from commonwealth.utils.general import is_running_as_root
 from commonwealth.utils.logs import InterceptHandler, get_new_log_path
 from fastapi import Body, FastAPI, File, HTTPException, Response, UploadFile, status
 from fastapi.staticfiles import StaticFiles
@@ -41,7 +42,8 @@ app = FastAPI(
 )
 logger.info("Starting ArduPilot Manager.")
 autopilot = ArduPilotManager()
-autopilot.check_running_as_root()
+if not is_running_as_root():
+    raise RuntimeError("ArduPilot manager needs to run with root privilege.")
 
 
 @app.get("/endpoints", response_model=List[Dict[str, Any]])

--- a/core/services/ardupilot_manager/mavlink_proxy/AbstractRouter.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/AbstractRouter.py
@@ -84,7 +84,7 @@ class AbstractRouter(metaclass=abc.ABCMeta):
     def master_endpoint(self) -> Optional[Endpoint]:
         return self._master_endpoint
 
-    def start(self, master_endpoint: Endpoint, _verbose: bool = False) -> None:
+    def start(self, master_endpoint: Endpoint) -> None:
         self._master_endpoint = master_endpoint
         command = self.assemble_command(self._master_endpoint)
         logger.debug(f"Calling router using following command: '{command}'.")

--- a/core/services/ardupilot_manager/mavlink_proxy/AbstractRouter.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/AbstractRouter.py
@@ -102,10 +102,10 @@ class AbstractRouter(metaclass=abc.ABCMeta):
 
     def exit(self) -> None:
         if self.is_running():
-            assert self._subprocess is not None
-            self._subprocess.kill()
+            # `is_running` already infers `_subprocess` is not None
+            self._subprocess.kill()  # type: ignore
         else:
-            logger.info("Tried to stop router, but it was already not running.")
+            logger.debug("Tried to stop router, but it was already not running.")
 
     def restart(self) -> None:
         if self._master_endpoint is None:

--- a/core/services/ardupilot_manager/mavlink_proxy/main.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/main.py
@@ -51,10 +51,9 @@ if __name__ == "__main__":
 
     manager.use(tool)
     manager.add_endpoints(args.output.split(":"))
-    manager.set_master_endpoint(args.master.split(":"))
 
     logger.info(f"Command: {manager.command_line()}")
-    manager.start()
+    manager.start(args.master.split(":"))
     while manager.is_running():
         time.sleep(1)
     logger.info("Done.")

--- a/core/services/ardupilot_manager/mavlink_proxy/test_all.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/test_all.py
@@ -168,8 +168,7 @@ def run_common_routing_tests(
 
     for endpoint in unallowed_master_endpoints:
         with pytest.raises(ValueError):
-            router.set_master_endpoint(endpoint)
-            router.start()
+            router.start(endpoint)
 
     def test_endpoint_combinations(master_endpoints: Set[Endpoint], output_endpoints: List[Endpoint]) -> None:
         for master_endpoint in master_endpoints:
@@ -179,8 +178,7 @@ def run_common_routing_tests(
                 router.add_endpoint(output_endpoint)
             assert set(router.endpoints()) == set(output_endpoints), "Endpoint list does not match."
 
-            router.set_master_endpoint(master_endpoint)
-            router.start()
+            router.start(master_endpoint)
             assert router.is_running(), f"{router.name()} is not running after start."
             router.exit()
             while router.is_running():

--- a/core/services/ardupilot_manager/setup.py
+++ b/core/services/ardupilot_manager/setup.py
@@ -45,6 +45,7 @@ static_files = [
         "https://s3.us-west-1.amazonaws.com/ardusub.bluerobotics.com/test-builds/ardusub-410-beta3-navigator-r5",
     ),
     StaticFile(defaults_folder, "ardupilot_pixhawk1", "https://firmware.ardupilot.org/Sub/latest/Pixhawk1/ardusub.apj"),
+    StaticFile(defaults_folder, "ardupilot_pixhawk4", "https://firmware.ardupilot.org/Sub/latest/Pixhawk4/ardusub.apj"),
 ]
 
 for file in static_files:

--- a/core/services/ardupilot_manager/typedefs.py
+++ b/core/services/ardupilot_manager/typedefs.py
@@ -122,6 +122,10 @@ class FlightController(BaseModel):
     platform: Platform
     path: Optional[str]
 
+    @property
+    def type(self) -> PlatformType:
+        return self.platform.type
+
 
 class FirmwareFormat(str, Enum):
     """Valid firmware formats.

--- a/core/services/ardupilot_manager/typedefs.py
+++ b/core/services/ardupilot_manager/typedefs.py
@@ -103,7 +103,6 @@ class Platform(str, Enum):
     Pixhawk1 = "Pixhawk1"
     Navigator = "navigator"
     SITL = get_sitl_platform_name(machine())
-    Undefined = "Undefined"
 
     @property
     def type(self) -> PlatformType:

--- a/core/services/ardupilot_manager/typedefs.py
+++ b/core/services/ardupilot_manager/typedefs.py
@@ -101,6 +101,7 @@ class Platform(str, Enum):
     The Enum values are 1:1 representations of the platforms available on the ArduPilot manifest."""
 
     Pixhawk1 = "Pixhawk1"
+    Pixhawk4 = "Pixhawk4"
     Navigator = "navigator"
     SITL = get_sitl_platform_name(machine())
 
@@ -108,6 +109,7 @@ class Platform(str, Enum):
     def type(self) -> PlatformType:
         platform_types = {
             Platform.Pixhawk1: PlatformType.Serial,
+            Platform.Pixhawk4: PlatformType.Serial,
             Platform.Navigator: PlatformType.Linux,
             Platform.SITL: PlatformType.SITL,
         }

--- a/core/services/ardupilot_manager/typedefs.py
+++ b/core/services/ardupilot_manager/typedefs.py
@@ -102,6 +102,7 @@ class Platform(str, Enum):
 
     Pixhawk1 = "Pixhawk1"
     Pixhawk4 = "Pixhawk4"
+    GenericSerial = "GenericSerial"
     Navigator = "navigator"
     SITL = get_sitl_platform_name(machine())
 
@@ -110,6 +111,7 @@ class Platform(str, Enum):
         platform_types = {
             Platform.Pixhawk1: PlatformType.Serial,
             Platform.Pixhawk4: PlatformType.Serial,
+            Platform.GenericSerial: PlatformType.Serial,
             Platform.Navigator: PlatformType.Linux,
             Platform.SITL: PlatformType.SITL,
         }

--- a/install/udev/100.autopilot.rules
+++ b/install/udev/100.autopilot.rules
@@ -1,6 +1,3 @@
-SUBSYSTEM=="tty", ATTRS{manufacturer}=="3D Robotics", ATTRS{product}=="PX4*", SYMLINK+="autopilot", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
-SUBSYSTEM=="tty", ATTRS{manufacturer}=="ArduPilot", SYMLINK+="autopilot", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
-
 # CP210X USB UART
 ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", MODE:="0666", ENV{ID_MM_DEVICE_IGNORE}="1", ENV{ID_MM_PORT_IGNORE}="1"
 


### PR DESCRIPTION
- Fully support Pixhawk4 (add support for firmware management and correct board detection);
- Allow toggling between different connected boards (specially useful for development and testing);
- Disallow firmware management for unsupported board (not Pixhawk1 nor Pixhawk4), preventing bad firmware uploads;
- Improve board detection, preventing bootloader from being as a fully booted board;
- Prevent ardupilot binaries being left running by pruning them all (and not only the one running);
- Make mavlink-router behavior more predictable by always asking for master-endpoint on start, preventing, for example, bad restarts from the watchdog;
- Make FlightController the central logic piece for ArdupilotManager, in place of Platform;

...and some other small code/logic improvements.

Fix #810
Fix #713
Fix #452
Fix #393 

Image available at `rafaellehmkuhl/companion-core`