### PR TITLE
core: Add global exception handler

### DIFF
--- a/core/frontend/src/components/app/PowerMenu.vue
+++ b/core/frontend/src/components/app/PowerMenu.vue
@@ -185,10 +185,7 @@ export default Vue.extend({
           if (error.code === 'ECONNABORTED') {
             return
           }
-
-          const detail_message = 'detail' in error.response.data
-            ? error.response.data.detail : ''
-          const message = `Failed to commit operation: ${error.message}, ${detail_message}`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: commander_service, type: 'SHUTDOWN_FAIL', message })
         })
     },

--- a/core/frontend/src/components/app/SettingsMenu.vue
+++ b/core/frontend/src/components/app/SettingsMenu.vue
@@ -109,9 +109,7 @@ export default Vue.extend({
           this.show_reset_dialog = true
         })
         .catch((error) => {
-          const detail_message = 'data' in error.response
-            && 'message' in error.response.data ? error.response.data.message : 'No details available.'
-          const message = `Failed to commit operation: ${error.message}, ${detail_message}`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: commander_service, type: 'RESET_SETTINGS_FAIL', message })
         })
     },

--- a/core/frontend/src/components/autopilot/AutopilotManagerUpdater.vue
+++ b/core/frontend/src/components/autopilot/AutopilotManagerUpdater.vue
@@ -39,7 +39,7 @@ export default Vue.extend({
         .catch((error) => {
           autopilot.setAvailableEndpoints([])
           if (error === backend_offline_error) { return }
-          const message = `Could not fetch available MAVLink endpoints: ${error.message}`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_ENDPOINT_FETCH_FAIL', message })
         })
     },
@@ -56,7 +56,7 @@ export default Vue.extend({
         .catch((error) => {
           autopilot.setAvailableBoards([])
           if (error === backend_offline_error) { return }
-          const message = `Could not fetch available Ardupilot boards: ${error.message}`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_BOARDS_FETCH_FAIL', message })
         })
     },
@@ -72,7 +72,7 @@ export default Vue.extend({
         .catch((error) => {
           autopilot.setCurrentBoard(null)
           if (error === backend_offline_error) { return }
-          const message = `Could not fetch current Autopilot board: ${error.message}`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_BOARD_FETCH_FAIL', message })
         })
     },

--- a/core/frontend/src/components/autopilot/EndpointCard.vue
+++ b/core/frontend/src/components/autopilot/EndpointCard.vue
@@ -198,7 +198,7 @@ export default Vue.extend({
         data: [this.endpoint],
       })
         .catch((error) => {
-          const message = `Could not remove endpoint: ${error.message}.`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_ENDPOINT_DELETE_FAIL', message })
         })
     },
@@ -215,7 +215,7 @@ export default Vue.extend({
         data: [this.updated_endpoint],
       })
         .catch((error) => {
-          const message = `Could not update endpoint: ${error.message}.`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_ENDPOINT_UPDATE_FAIL', message })
         })
     },

--- a/core/frontend/src/components/autopilot/EndpointCreationDialog.vue
+++ b/core/frontend/src/components/autopilot/EndpointCreationDialog.vue
@@ -160,7 +160,7 @@ export default Vue.extend({
           this.form.reset()
         })
         .catch((error) => {
-          const message = `Could not create endpoint: ${error.message}.`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_ENDPOINT_CREATE_FAIL', message })
         })
       return true

--- a/core/frontend/src/components/autopilot/FirmwareManager.vue
+++ b/core/frontend/src/components/autopilot/FirmwareManager.vue
@@ -244,7 +244,7 @@ export default Vue.extend({
         .catch((error) => {
           this.cloud_firmware_options_status = CloudFirmwareOptionsStatus.FetchFailed
           if (error === backend_offline_error) { return }
-          const message = `Could not fetch available firmwares: ${error.message}.`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'FIRMWARE_FETCH_FAIL', message })
         })
     },
@@ -299,11 +299,7 @@ export default Vue.extend({
           if (error.message && error.message === 'Network Error') {
             this.install_result_message = 'Upload fail. If the file was changed, clean the form and re-select it.'
           } else {
-            try {
-              this.install_result_message = error.response.data.message
-            } catch {
-              this.install_result_message = 'Invalid backend error message.'
-            }
+            this.install_result_message = error.response.data.detail ?? error.message
           }
           const message = `Could not install firmware: ${this.install_result_message}.`
           notifications.pushError({ service: autopilot_service, type: 'FILE_FIRMWARE_INSTALL_FAIL', message })

--- a/core/frontend/src/components/bridges/BridgeCard.vue
+++ b/core/frontend/src/components/bridges/BridgeCard.vue
@@ -64,7 +64,7 @@ export default Vue.extend({
         data: this.bridge,
       })
         .catch((error) => {
-          const message = `Could not remove bridge: ${error.message}.`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: bridget_service, type: 'BRIDGE_DELETE_FAIL', message })
         })
     },

--- a/core/frontend/src/components/bridges/BridgeCreationDialog.vue
+++ b/core/frontend/src/components/bridges/BridgeCreationDialog.vue
@@ -153,7 +153,7 @@ export default Vue.extend({
           this.form.reset()
         })
         .catch((error) => {
-          const message = `Could not create bridge: ${error.message}.`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: bridget_service, type: 'BRIDGE_CREATE_FAIL', message })
         })
       return true

--- a/core/frontend/src/components/ethernet/AddressCreationDialog.vue
+++ b/core/frontend/src/components/ethernet/AddressCreationDialog.vue
@@ -134,7 +134,7 @@ export default Vue.extend({
           this.form.reset()
         })
         .catch((error) => {
-          const message = `Could not create new address on ${this.interfaceName}: ${error.message}.`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: ethernet_service, type: 'ETHERNET_ADDRESS_CREATION_FAIL', message })
         })
       return true

--- a/core/frontend/src/components/ethernet/EthernetUpdater.vue
+++ b/core/frontend/src/components/ethernet/EthernetUpdater.vue
@@ -29,7 +29,7 @@ export default Vue.extend({
         .catch((error) => {
           ethernet.setInterfaces([])
           if (error === backend_offline_error) { return }
-          const message = `Could not fetch for available ethernet interfaces: ${error.message}`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: ethernet_service, type: 'ETHERNET_AVAILABLE_FETCH_FAIL', message })
         })
     },

--- a/core/frontend/src/components/ethernet/InterfaceCard.vue
+++ b/core/frontend/src/components/ethernet/InterfaceCard.vue
@@ -108,7 +108,7 @@ export default Vue.extend({
         params: { interface_name: this.adapter.name, ip_address: ip },
       })
         .catch((error) => {
-          const message = `Could not delete address '${ip}' on '${this.adapter.name}': ${error.message}.`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: ethernet_service, type: 'ETHERNET_ADDRESS_DELETE_FAIL', message })
         })
     },

--- a/core/frontend/src/components/nmea-injector/NMEAInjectorUpdater.vue
+++ b/core/frontend/src/components/nmea-injector/NMEAInjectorUpdater.vue
@@ -37,7 +37,7 @@ export default Vue.extend({
         .catch((error) => {
           nmea_injector.setAvailableNMEASockets([])
           if (error === backend_offline_error) { return }
-          const message = `Could not fetch available bridges: ${error.message}`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: nmea_injector_service, type: 'BRIDGES_FETCH_FAIL', message })
         })
         .finally(() => {

--- a/core/frontend/src/components/nmea-injector/NMEASocketCard.vue
+++ b/core/frontend/src/components/nmea-injector/NMEASocketCard.vue
@@ -64,7 +64,7 @@ export default Vue.extend({
         data: this.nmeaSocket,
       })
         .catch((error) => {
-          const message = `Could not remove NMEA socket: ${error.message}.`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: nmea_injector_service, type: 'nmeaSocket_DELETE_FAIL', message })
         })
     },

--- a/core/frontend/src/components/nmea-injector/NMEASocketCreationDialog.vue
+++ b/core/frontend/src/components/nmea-injector/NMEASocketCreationDialog.vue
@@ -134,7 +134,7 @@ export default Vue.extend({
           this.form.reset()
         })
         .catch((error) => {
-          const message = `Could not create NMEA socket: ${error.message}.`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: nmea_injector_service, type: 'NMEA_SOCKET_CREATE_FAIL', message })
         })
       return true

--- a/core/frontend/src/components/wifi/ConnectionDialog.vue
+++ b/core/frontend/src/components/wifi/ConnectionDialog.vue
@@ -233,7 +233,7 @@ export default Vue.extend({
         })
         .catch((error) => {
           this.connection_status = ConnectionStatus.Failed
-          let message = error.response.data.detail ? error.response.data.detail : `Connection failed: ${error}`
+          let message = error.response.data.detail ?? error.message
           message = message.concat('\n', 'Please check if the password is correct.')
           this.connection_result_message = message
           notifications.pushError({ service: wifi_service, type: 'WIFI_CONNECT_FAIL', message })
@@ -247,7 +247,7 @@ export default Vue.extend({
         params: { ssid: this.network.ssid },
       })
         .catch((error) => {
-          const message = error.response.data.detail ? error.response.data.detail : `Connection failed: ${error}`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: wifi_service, type: 'WIFI_FORGET_FAIL', message })
         })
         .finally(() => {

--- a/core/frontend/src/store/bridget.ts
+++ b/core/frontend/src/store/bridget.ts
@@ -86,7 +86,7 @@ class BridgetStore extends VuexModule {
       .catch((error) => {
         this.setAvailableBridges([])
         if (error === backend_offline_error) { return }
-        const message = `Could not fetch available bridges: ${error.message}`
+        const message = error.response.data.detail ?? error.message
         notifications.pushError({ service: bridget_service, type: 'BRIDGES_FETCH_FAIL', message })
       })
       .finally(() => {
@@ -112,7 +112,7 @@ class BridgetStore extends VuexModule {
       .catch((error) => {
         this.setAvailableSerialPorts([])
         if (error === backend_offline_error) { return }
-        const message = `Could not fetch available serial ports: ${error.message}`
+        const message = error.response.data.detail ?? error.message
         notifications.pushError({ service: bridget_service, type: 'BRIDGET_SERIAL_PORTS_FETCH_FAIL', message })
       })
       .finally(() => {

--- a/core/frontend/src/utils/update_time.ts
+++ b/core/frontend/src/utils/update_time.ts
@@ -21,7 +21,7 @@ export default async function run() : Promise<void> {
         return
       }
 
-      const message = `Failed to commit operation: ${error.message}`
+      const message = error.response.data.detail ?? error.message
       notifications.pushError({ service: update_time_service, type: 'UPDATE_TIME_FAIL', message })
     })
 }

--- a/core/frontend/src/views/GeneralAutopilot.vue
+++ b/core/frontend/src/views/GeneralAutopilot.vue
@@ -88,7 +88,7 @@ export default Vue.extend({
         timeout: 10000,
       })
         .catch((error) => {
-          const message = `Could not start autopilot: ${error.message}`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_START_FAIL', message })
         })
         .finally(() => {
@@ -103,7 +103,7 @@ export default Vue.extend({
         timeout: 10000,
       })
         .catch((error) => {
-          const message = `Could not stop autopilot: ${error.message}`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_STOP_FAIL', message })
         })
         .finally(() => {
@@ -118,7 +118,7 @@ export default Vue.extend({
         timeout: 10000,
       })
         .catch((error) => {
-          const message = `Could not restart autopilot: ${error.message}`
+          const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_RESTART_FAIL', message })
         })
         .finally(() => {

--- a/core/services/commander/main.py
+++ b/core/services/commander/main.py
@@ -9,8 +9,9 @@ from typing import Any
 
 import appdirs
 import uvicorn
+from commonwealth.utils.apis import GenericErrorHandlingRoute
 from commonwealth.utils.logs import InterceptHandler, get_new_log_path
-from fastapi import FastAPI, HTTPException, Response, status
+from fastapi import FastAPI, HTTPException, status
 from fastapi.responses import HTMLResponse
 from fastapi_versioning import VersionedFastAPI, version
 from loguru import logger
@@ -24,6 +25,7 @@ app = FastAPI(
     title="Commander API",
     description="Commander is a BlueOS service responsible to abstract simple commands to the frontend.",
 )
+app.router.route_class = GenericErrorHandlingRoute
 logger.info("Starting Commander!")
 
 
@@ -68,29 +70,22 @@ def check_what_i_am_doing(i_know_what_i_am_doing: bool = False) -> None:
 
 @app.post("/command/host", status_code=status.HTTP_200_OK)
 @version(1, 0)
-async def command_host(response: Response, command: str, i_know_what_i_am_doing: bool = False) -> Any:
+async def command_host(command: str, i_know_what_i_am_doing: bool = False) -> Any:
     check_what_i_am_doing(i_know_what_i_am_doing)
     logger.debug(f"Running command: {command}")
-
-    try:
-        output = run_command(command, False)
-        logger.debug(f"Output: {output}")
-        response.status_code = status.HTTP_200_OK
-        message = {
-            "stdout": f"{output.stdout!r}",
-            "stderr": f"{output.stderr!r}",
-            "return_code": output.returncode,
-        }
-        return message
-    except Exception as error:
-        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
-        logger.exception(error)
-        return {"message": f"{error}"}
+    output = run_command(command, False)
+    logger.debug(f"Output: {output}")
+    message = {
+        "stdout": f"{output.stdout!r}",
+        "stderr": f"{output.stderr!r}",
+        "return_code": output.returncode,
+    }
+    return message
 
 
 @app.post("/set_time", status_code=status.HTTP_200_OK)
 @version(1, 0)
-async def set_time(response: Response, unix_time_seconds: int, i_know_what_i_am_doing: bool = False) -> Any:
+async def set_time(unix_time_seconds: int, i_know_what_i_am_doing: bool = False) -> Any:
     unix_time_seconds_now = int(time.time())
     if abs(unix_time_seconds_now - unix_time_seconds) < 5 * 60:
         return {
@@ -100,53 +95,38 @@ async def set_time(response: Response, unix_time_seconds: int, i_know_what_i_am_
 
     # It's necessary to stop ntp sync before setting time
     command = f"sudo timedatectl set-ntp false; sudo date -s '@{unix_time_seconds}'; sudo timedatectl set-ntp true"
-    return await command_host(response, command, i_know_what_i_am_doing)
+    return await command_host(command, i_know_what_i_am_doing)
 
 
 # TODO: Update commander to work with openapi modules and improve modularity and code organization
 @app.post("/shutdown", status_code=status.HTTP_200_OK)
 @version(1, 0)
-async def shutdown(response: Response, shutdown_type: ShutdownType, i_know_what_i_am_doing: bool = False) -> Any:
+async def shutdown(shutdown_type: ShutdownType, i_know_what_i_am_doing: bool = False) -> Any:
     check_what_i_am_doing(i_know_what_i_am_doing)
-
-    try:
-        hold_time_seconds = 5
-        if shutdown_type == ShutdownType.REBOOT:
-            output = run_command(f"(sleep {hold_time_seconds}; sudo reboot)&")
-            logger.debug(f"reboot: {output}")
-        elif shutdown_type == ShutdownType.POWEROFF:
-            output = run_command(f"(sleep {hold_time_seconds}; sudo shutdown --poweroff -h now)&")
-            logger.debug(f"shutdown: {output}")
-
-        return HTMLResponse(status_code=200)
-    except Exception as error:
-        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
-        logger.exception(error)
-        return {"message": f"{error}"}
+    hold_time_seconds = 5
+    if shutdown_type == ShutdownType.REBOOT:
+        output = run_command(f"(sleep {hold_time_seconds}; sudo reboot)&")
+        logger.debug(f"reboot: {output}")
+    elif shutdown_type == ShutdownType.POWEROFF:
+        output = run_command(f"(sleep {hold_time_seconds}; sudo shutdown --poweroff -h now)&")
+        logger.debug(f"shutdown: {output}")
 
 
 @app.post("/settings/reset", status_code=status.HTTP_200_OK)
 @version(1, 0)
-async def reset_settings(response: Response, i_know_what_i_am_doing: bool = False) -> Any:
+async def reset_settings(i_know_what_i_am_doing: bool = False) -> Any:
     check_what_i_am_doing(i_know_what_i_am_doing)
 
-    try:
-        user_config_dir = Path(appdirs.user_config_dir())
-        for item in user_config_dir.glob("*"):
-            try:
-                if item.is_file():
-                    item.unlink()
-                if item.is_dir():
-                    # Delete folder and its contents
-                    shutil.rmtree(item)
-            except Exception as exception:
-                logger.warning(f"Failed to delete: {item}, {exception}")
-
-        return HTMLResponse(status_code=200)
-    except Exception as error:
-        response.status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
-        logger.exception(error)
-        return {"message": f"Could not reset user configuration, {error}"}
+    user_config_dir = Path(appdirs.user_config_dir())
+    for item in user_config_dir.glob("*"):
+        try:
+            if item.is_file():
+                item.unlink()
+            if item.is_dir():
+                # Delete folder and its contents
+                shutil.rmtree(item)
+        except Exception as exception:
+            logger.warning(f"Failed to delete: {item}, {exception}")
 
 
 app = VersionedFastAPI(app, version="1.0.0", prefix_format="/v{major}.{minor}", enable_latest=True)

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -8,7 +8,7 @@ import psutil
 import requests
 import uvicorn
 from bs4 import BeautifulSoup
-from commonwealth.utils.apis import PrettyJSONResponse
+from commonwealth.utils.apis import GenericErrorHandlingRoute, PrettyJSONResponse
 from commonwealth.utils.decorators import temporary_cache
 from fastapi import FastAPI
 from fastapi.staticfiles import StaticFiles
@@ -100,6 +100,7 @@ fast_api_app = FastAPI(
     description="Everybody's helper to find web services that are running in BlueOS.",
     default_response_class=PrettyJSONResponse,
 )
+fast_api_app.router.route_class = GenericErrorHandlingRoute
 
 
 @fast_api_app.get(

--- a/core/services/ping/main.py
+++ b/core/services/ping/main.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 from typing import Any, List
 
-from commonwealth.utils.apis import PrettyJSONResponse
+from commonwealth.utils.apis import GenericErrorHandlingRoute, PrettyJSONResponse
 from commonwealth.utils.logs import InterceptHandler, get_new_log_path
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse
@@ -25,6 +25,7 @@ app = FastAPI(
     default_response_class=PrettyJSONResponse,
     debug=True,
 )
+app.router.route_class = GenericErrorHandlingRoute
 logger.info("Starting Ping Service.")
 
 # TODO: move to singleton


### PR DESCRIPTION
- Use a global exception handler, so exceptions not caught are all logged and return a default HTTP status-code of 500 with the exception message appended;
- Adapt the frontend of the services to consider this new standard.

With this new approach, we guarantee every not-handled exception to be in the logs, making debug easier, both for frontend and local. Error messages more specific than "returned status code of 500" will start to come.

Image available at `rafaellehmkuhl/blueos-core`