### PR TITLE
Core: frontend: turn welcome card into a dismissible alert

### DIFF
--- a/core/frontend/src/views/MainView.vue
+++ b/core/frontend/src/views/MainView.vue
@@ -1,24 +1,31 @@
 <template>
   <v-container>
-    <v-card id="welcome-card">
-      <v-card-title><p>Welcome to BlueOS!</p></v-card-title>
-      <v-card-text>
-        <p>
-          Before start using, we highly recommend to <a
-            href="https://docs.bluerobotics.com/ardusub-zola/software/companion/1.0/configuration/#connect-wifi"
-          >
-            connect first on the internet
-          </a>
-          and do the
-          <a href="https://docs.bluerobotics.com/ardusub-zola/software/companion/1.0/configuration/#select-version">
-            system update to the latest version available
-          </a>
-          .
-        </p>
-        <v-card-text />
-      </v-card-text>
-    </v-card>
-
+    <v-row
+      class="mb-6 mt-6"
+      justify="center"
+      no-gutters
+    >
+      <v-alert
+        border="top"
+        colored-border
+        type="info"
+        elevation="2"
+        dismissible
+        class=''
+      >
+      <h3>Welcome to BlueOS!</h3>
+        Before start using, we highly recommend to <a
+          href="https://docs.bluerobotics.com/ardusub-zola/software/companion/1.0/configuration/#connect-wifi"
+        >
+          connect first on the internet
+        </a>
+        and do the
+        <a href="https://docs.bluerobotics.com/ardusub-zola/software/companion/1.0/configuration/#select-version">
+          system update to the latest version available
+        </a>
+        .
+      </v-alert>
+    </v-row>
     <v-row>
       <v-col
         v-for="({ icon, title, text, route, advanced}, i) in apps"


### PR DESCRIPTION
It will still show up everytime for now, but so would the previous one
![alert](https://user-images.githubusercontent.com/4013804/159808332-93b76a0b-bffc-4729-89b2-e7188def843f.gif)
