### PR TITLE
frontend: Dont break words in titles

### DIFF
--- a/core/frontend/src/assets/css/vuetify-global.css
+++ b/core/frontend/src/assets/css/vuetify-global.css
@@ -1,0 +1,4 @@
+/* Prevent words in titles to break in half */
+.v-card__text, .v-card__title {
+    word-break: normal;
+}

--- a/core/frontend/src/main.ts
+++ b/core/frontend/src/main.ts
@@ -8,6 +8,7 @@ import vuetify from './plugins/vuetify'
 import router from './router'
 import store from './store'
 
+require('@/assets/css/vuetify-global.css')
 require('vue-tour/dist/vue-tour.css')
 
 Vue.use(VueTooltipDirective, {


### PR DESCRIPTION
- Add global Vuetify CSS rules
- Add rule preventing words in titles from breaking in half

Examples before and after:

<img width="270" alt="image" src="https://user-images.githubusercontent.com/6551040/159987773-1cec339f-713e-4797-ace2-a85dad93d6ea.png"><img width="268" alt="image" src="https://user-images.githubusercontent.com/6551040/159987817-b667f0a6-7bd5-4bd6-946d-56ffa58b51ad.png">