### PR TITLE
frontend: Improve pirate-mode warn text

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -6,6 +6,8 @@
       <v-app-bar
         rounded="0"
         :color="app_bar_color"
+        :extended="extend_toolbar"
+        extension-height="10"
       >
         <v-app-bar-nav-icon
           id="hamburguer-menu-button"
@@ -14,27 +16,27 @@
         />
 
         <v-spacer />
-        <div
-          v-if="settings.is_pirate_mode"
-        >
-          Ahoy matey! You're running
-          <v-icon>
-            mdi-flag-variant
-          </v-icon>
-          <v-icon>
-            mdi-skull-crossbones
-          </v-icon>
-          Pirate Mode
-          <v-icon>
-            mdi-skull-crossbones
-          </v-icon>
-          <v-icon>
-            mdi-flag-variant
-          </v-icon>
-        </div>
-
-        <backend-status-checker @statusChange="changeBackendStatus" />
+        <span class="d-flex flex-column align-center">
+          <backend-status-checker @statusChange="changeBackendStatus" />
+          <span v-if="settings.is_pirate_mode">
+            Ahoy matey! You're running
+            <v-icon>
+              mdi-flag-variant
+            </v-icon>
+            <v-icon>
+              mdi-skull-crossbones
+            </v-icon>
+            Pirate Mode
+            <v-icon>
+              mdi-skull-crossbones
+            </v-icon>
+            <v-icon>
+              mdi-flag-variant
+            </v-icon>
+          </span>
+        </span>
         <v-spacer />
+
         <health-tray-menu />
         <wifi-tray-menu />
         <ethernet-tray-menu />
@@ -212,6 +214,9 @@ export default Vue.extend({
     menus,
   }),
   computed: {
+    extend_toolbar(): boolean {
+      return settings.is_pirate_mode && this.backend_offline
+    },
     steps() {
       return [
         {

--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -19,7 +19,7 @@
         <span class="d-flex flex-column align-center">
           <backend-status-checker @statusChange="changeBackendStatus" />
           <span v-if="settings.is_pirate_mode">
-            Ahoy matey! You're running
+            <span class="d-none d-md-flex d-lg-none">Ahoy matey! You're running</span>
             <v-icon>
               mdi-flag-variant
             </v-icon>


### PR DESCRIPTION
- Make text suitable for mobile screens
- Make text more clear when on disconnected state

Before: <img width="856" alt="image" src="https://user-images.githubusercontent.com/6551040/159998601-59cc4af4-f76b-4682-8e65-057913101ff8.png">
After: <img width="861" alt="image" src="https://user-images.githubusercontent.com/6551040/159998738-1f55c91b-0784-49b6-b4be-057e86356149.png">


Before and after: 
<img width="376" alt="image" src="https://user-images.githubusercontent.com/6551040/160001613-95300e80-e8f2-405c-839d-17cbf1dbbced.png"><img width="376" alt="image" src="https://user-images.githubusercontent.com/6551040/160001955-270fc465-2570-4d32-82ee-4fe8b372be00.png">

Yup, pirate-mode + disconnected on mobiles is also fine 😄 

Fix #769 