### PR TITLE
frontend: Make firmware buttons don't go one over another

### DIFF
--- a/core/frontend/src/components/autopilot/FirmwareManager.vue
+++ b/core/frontend/src/components/autopilot/FirmwareManager.vue
@@ -6,7 +6,7 @@
     <v-item-group
       v-model="upload_type"
       mandatory
-      class="ma-6"
+      class="ma-6 d-flex align-center justify-center flex-wrap"
     >
       <v-item
         v-slot="{ active, toggle }"
@@ -14,7 +14,7 @@
       >
         <v-btn
           :color="active ? 'primary' : ''"
-          class="mr-2"
+          class="ma-1"
           @click="toggle"
         >
           <v-icon class="mr-2">
@@ -29,7 +29,7 @@
       >
         <v-btn
           :color="active ? 'primary' : ''"
-          class="mr-2"
+          class="ma-1"
           @click="toggle"
         >
           <v-icon class="mr-2">
@@ -44,6 +44,7 @@
       >
         <v-btn
           :color="active ? 'primary' : ''"
+          class="ma-1"
           @click="toggle"
         >
           <v-icon class="mr-2">


### PR DESCRIPTION
Before and after:

<img width="317" alt="image" src="https://user-images.githubusercontent.com/6551040/160004830-2de4768e-57e7-4a05-8e19-367334e5eedc.png"><img width="314" alt="image" src="https://user-images.githubusercontent.com/6551040/160004751-019fb8dd-cc84-4815-bda5-936b8450a91a.png">
