### PR TITLE
core: beacon: set ttl to 25 seconds

### DIFF
--- a/core/services/beacon/main.py
+++ b/core/services/beacon/main.py
@@ -29,7 +29,7 @@ class AsyncRunner:
 
     async def register_services(self) -> None:
         self.aiozc = AsyncZeroconf(ip_version=self.ip_version, interfaces=[self.interfaces])  # type: ignore
-        tasks = [self.aiozc.async_register_service(info, cooperating_responders=True) for info in self.services]
+        tasks = [self.aiozc.async_register_service(info, cooperating_responders=True, ttl=25) for info in self.services]
         background_tasks = await asyncio.gather(*tasks)
         await asyncio.gather(*background_tasks)
         logger.info("Finished registration, press Ctrl-C to exit...")


### PR DESCRIPTION
The goal here is that the dns entry "drops" soon after a connection changes.
Say you disconnect from wifi, this will make the devices in your wifi network to drop blues.local from their dns tables after 25s

this is low priority, and it would be nice to have more testing done.