### PR TITLE
core: commander: use 'reboot' instead of 'shutdown -r' to reboot

### DIFF
--- a/core/services/commander/main.py
+++ b/core/services/commander/main.py
@@ -112,7 +112,7 @@ async def shutdown(response: Response, shutdown_type: ShutdownType, i_know_what_
     try:
         hold_time_seconds = 5
         if shutdown_type == ShutdownType.REBOOT:
-            output = run_command(f"(sleep {hold_time_seconds}; sudo shutdown --reboot -h now)&")
+            output = run_command(f"(sleep {hold_time_seconds}; sudo reboot)&")
             logger.debug(f"reboot: {output}")
         elif shutdown_type == ShutdownType.POWEROFF:
             output = run_command(f"(sleep {hold_time_seconds}; sudo shutdown --poweroff -h now)&")


### PR DESCRIPTION
fixes an issue where the pi is shutting down instead of rebooting.

image will be up at williangalvani/blueos-core:reboot when CI finishes.