### PR TITLE
frontend: home: Small frontend fixes

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -19,7 +19,7 @@
         <span class="d-flex flex-column align-center">
           <backend-status-checker @statusChange="changeBackendStatus" />
           <span v-if="settings.is_pirate_mode">
-            <span class="d-none d-md-flex d-lg-none">Ahoy matey! You're running</span>
+            <span class="hidden-sm-and-down">Ahoy matey! You're running</span>
             <v-icon>
               mdi-flag-variant
             </v-icon>

--- a/core/frontend/src/components/autopilot/EndpointCard.vue
+++ b/core/frontend/src/components/autopilot/EndpointCard.vue
@@ -11,7 +11,7 @@
             class="pa-1"
           >
             <v-card class="elevation-0 d-flex flex-column align-center pa-0">
-              <p class="ma-0 pt-2 text-h5">
+              <p class="ma-0 pt-2 text-h5 text-center">
                 {{ endpoint.name }}
               </p>
               <p class="ma-0 pb-2 text-body-2">

--- a/core/frontend/src/views/GeneralAutopilot.vue
+++ b/core/frontend/src/views/GeneralAutopilot.vue
@@ -7,10 +7,11 @@
       <span v-if="board_undefined">No board running</span>
       <span v-else>Currently running: '{{ current_board.name }}'</span>
     </v-card-subtitle>
-    <v-card-actions>
+    <v-card-actions class="d-flex justify-end align-center flex-wrap">
       <v-spacer />
       <v-btn
         color="blue lighten-3"
+        class="ma-1"
         :disabled="restarting"
         @click="openBoardChangeDialog"
       >
@@ -18,6 +19,7 @@
       </v-btn>
       <v-btn
         v-if="settings.is_pirate_mode"
+        class="ma-1"
         color="red lighten-3"
         :disabled="restarting"
         @click="start_autopilot"
@@ -26,6 +28,7 @@
       </v-btn>
       <v-btn
         v-if="settings.is_pirate_mode"
+        class="ma-1"
         color="red lighten-3"
         :disabled="restarting"
         @click="stop_autopilot"
@@ -34,6 +37,7 @@
       </v-btn>
       <v-btn
         color="red lighten-3"
+        class="ma-1"
         :disabled="restarting"
         @click="restart_autopilot"
       >

--- a/core/frontend/src/views/MainView.vue
+++ b/core/frontend/src/views/MainView.vue
@@ -41,13 +41,12 @@
         >
           <v-theme-provider dark>
             <v-row
-              class="py-3 px-3"
+              class="py-3 px-3 d-flex justify-space-between flex-nowrap"
             >
               <v-card-title
                 class="text-subtitle-1 font-weight-bold"
                 v-text="title"
               />
-              <v-spacer />
               <div>
                 <v-avatar
                   color="primary"


### PR DESCRIPTION
This PR will group some small frontend fixes:

Avatars on home tiles:
![image](https://user-images.githubusercontent.com/6551040/160660626-584761d5-b061-40cc-b754-429ea07d61ef.png)![image](https://user-images.githubusercontent.com/6551040/160660591-e3ea0778-f6c6-4706-9f77-e31ed5a6f59b.png)

Buttons on autopilot/general:
![image](https://user-images.githubusercontent.com/6551040/160675565-bb895ca0-d758-49cf-991a-b7e4b46b8f00.png)![image](https://user-images.githubusercontent.com/6551040/160675496-a9f6d07a-d6c0-4c32-b74c-f73249f940f5.png)

Endpoint name on autopilot/endpoints:

![image](https://user-images.githubusercontent.com/6551040/160683458-041ee5ad-10cf-4b71-b42f-ecea01ef454b.png)![image](https://user-images.githubusercontent.com/6551040/160683487-e91b0ae8-3ace-4415-a3f1-35ebe5f644af.png)


Fix pirate "ahoy" message showing on medium screens but not on large ones:
![image](https://user-images.githubusercontent.com/6551040/160684983-f1d37f23-1825-48be-ba61-bdb3f20827fb.png)
![image](https://user-images.githubusercontent.com/6551040/160684957-04a4a999-d601-43c7-9596-2d0f9e308983.png)
