### PR TITLE
core: frontend: mavlink: re-open mavlink websockets when connection is lost

### DIFF
--- a/core/frontend/src/libs/MAVLink2Rest/Endpoint.ts
+++ b/core/frontend/src/libs/MAVLink2Rest/Endpoint.ts
@@ -36,6 +36,11 @@ export default class Endpoint {
         listener.onNewData(this.latestData)
       }
     }
+    socket.onclose = () => {
+      setTimeout(() => {
+        this.socket = this.createSocket(url)
+      }, 5000)
+    }
     return socket
   }
 


### PR DESCRIPTION
fix #929

image will be up at williangalvani//blueos-core:reconnect after ci is done.