### PR TITLE
hooks: Disable shellcheck SC2048

### DIFF
--- a/.hooks/pre-push
+++ b/.hooks/pre-push
@@ -9,8 +9,9 @@ echo "Running shellcheck..."
 #SC2005: Allow us to break line while running command
 #SC2015: Allow us to use short circuit
 #SC2046: Allow word splitting
+#SC2048: Allow word splitting
 #SC2086: Allow word splitting
-git ls-files '*.sh' | xargs --max-lines=1 shellcheck --exclude=SC2005,SC2015,SC2046,SC2086
+git ls-files '*.sh' | xargs --max-lines=1 shellcheck --exclude=SC2005,SC2015,SC2046,SC2048,SC2086
 
 echo "Running isort.."
 # Run isort for each python project


### PR DESCRIPTION
This check needs to be disabled when whitespaces are necessary
for the command to work as a argument list.

E.g: `apt install -y gcc libudev-dev`