### PR TITLE
Improve available info about autopilot

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -44,7 +44,8 @@ jobs:
         pip install pyfakefs pytest-cov pytest-timeout pylint mypy isort black==22.1.0 asyncmock types-requests
         pip install git+https://github.com/patrickelectric/pykson.git@master_fixes
         ## Install our own libraries
-        ./core/libs/install-libs.sh
+        python ./core/libs/bridges/setup.py install
+        python ./core/libs/commonwealth/setup.py install
         ## We need to install loguru and appdirs since they may be used inside setup.py
         python -m pip install --user appdirs==1.4.4 loguru==0.5.3
         find . -type f -name "setup.py" | xargs --max-lines=1 --replace=% python % install --user

--- a/core/frontend/src/components/autopilot/AutopilotManagerUpdater.vue
+++ b/core/frontend/src/components/autopilot/AutopilotManagerUpdater.vue
@@ -3,6 +3,7 @@
 </template>
 
 <script lang="ts">
+import { AxiosResponse } from 'axios'
 import Vue from 'vue'
 
 import autopilot from '@/store/autopilot_manager'
@@ -24,6 +25,7 @@ export default Vue.extend({
     callPeriodically(this.fetchAvailableEndpoints, 5000)
     callPeriodically(this.fetchAvailableBoards, 5000)
     callPeriodically(this.fetchCurrentBoard, 5000)
+    callPeriodically(this.fetchFirmwareInfo, 5000)
   },
   methods: {
     async fetchAvailableEndpoints(): Promise<void> {
@@ -75,6 +77,21 @@ export default Vue.extend({
           const message = error.response.data.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_BOARD_FETCH_FAIL', message })
         })
+    },
+    async fetchFirmwareInfo(): Promise<void> {
+      try {
+        const response: AxiosResponse = await back_axios({
+          method: 'get',
+          url: `${autopilot.API_URL}/firmware_info`,
+          timeout: 10000,
+        })
+        autopilot.setFirmwareInfo(response.data)
+      } catch (error) {
+        autopilot.setFirmwareInfo(null)
+        if (error === backend_offline_error) { return }
+        const message = error.response?.data?.detail ?? error.message
+        notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_FIRM_INFO_FETCH_FAIL', message })
+      }
     },
   },
 })

--- a/core/frontend/src/components/autopilot/AutopilotManagerUpdater.vue
+++ b/core/frontend/src/components/autopilot/AutopilotManagerUpdater.vue
@@ -26,6 +26,7 @@ export default Vue.extend({
     callPeriodically(this.fetchAvailableBoards, 5000)
     callPeriodically(this.fetchCurrentBoard, 5000)
     callPeriodically(this.fetchFirmwareInfo, 5000)
+    callPeriodically(this.fetchVehicleType, 5000)
   },
   methods: {
     async fetchAvailableEndpoints(): Promise<void> {
@@ -91,6 +92,21 @@ export default Vue.extend({
         if (error === backend_offline_error) { return }
         const message = error.response?.data?.detail ?? error.message
         notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_FIRM_INFO_FETCH_FAIL', message })
+      }
+    },
+    async fetchVehicleType(): Promise<void> {
+      try {
+        const response: AxiosResponse = await back_axios({
+          method: 'get',
+          url: `${autopilot.API_URL}/vehicle_type`,
+          timeout: 10000,
+        })
+        autopilot.setVehicleType(response.data)
+      } catch (error) {
+        autopilot.setVehicleType(null)
+        if (error === backend_offline_error) { return }
+        const message = error.response?.data?.detail ?? error.message
+        notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_VEHICLE_TYPE_FETCH_FAIL', message })
       }
     },
   },

--- a/core/frontend/src/components/autopilot/FirmwareManager.vue
+++ b/core/frontend/src/components/autopilot/FirmwareManager.vue
@@ -237,11 +237,12 @@ export default Vue.extend({
         .map((firmware) => ({ value: firmware.url, text: firmware.name }))
         .filter((firmware) => firmware.text !== 'OFFICIAL')
         .sort((a, b) => {
-          const release_show_order = ['official', 'beta', 'dev', 'stable']
+          const release_show_order = ['dev', 'beta', 'stable']
           const prior_a = release_show_order.indexOf(a.text.toLowerCase().split('-')[0])
           const prior_b = release_show_order.indexOf(b.text.toLowerCase().split('-')[0])
           return prior_a > prior_b ? 1 : -1
         })
+        .reverse()
     },
     allow_installing(): boolean {
       if (this.install_status === InstallStatus.Installing) {

--- a/core/frontend/src/components/autopilot/FirmwareManager.vue
+++ b/core/frontend/src/components/autopilot/FirmwareManager.vue
@@ -235,6 +235,7 @@ export default Vue.extend({
     showable_firmwares(): {value: URL, text: string}[] {
       return this.available_firmwares
         .map((firmware) => ({ value: firmware.url, text: firmware.name }))
+        .filter((firmware) => firmware.text !== 'OFFICIAL')
         .sort((a, b) => {
           const release_show_order = ['official', 'beta', 'dev', 'stable']
           const prior_a = release_show_order.indexOf(a.text.toLowerCase().split('-')[0])

--- a/core/frontend/src/store/autopilot_manager.ts
+++ b/core/frontend/src/store/autopilot_manager.ts
@@ -22,6 +22,8 @@ class AutopilotManagerStore extends VuexModule {
 
   firmware_info: FirmwareInfo | null = null
 
+  vehicle_type: string | null = null
+
   updating_endpoints = true
 
   updating_boards = true
@@ -46,6 +48,11 @@ class AutopilotManagerStore extends VuexModule {
   @Mutation
   setFirmwareInfo(firmware_info: FirmwareInfo | null): void {
     this.firmware_info = firmware_info
+  }
+
+  @Mutation
+  setVehicleType(vehicle_type: string | null): void {
+    this.vehicle_type = vehicle_type
   }
 
   @Mutation

--- a/core/frontend/src/store/autopilot_manager.ts
+++ b/core/frontend/src/store/autopilot_manager.ts
@@ -3,7 +3,7 @@ import {
 } from 'vuex-module-decorators'
 
 import store from '@/store'
-import { AutopilotEndpoint, FlightController } from '@/types/autopilot'
+import { AutopilotEndpoint, FirmwareInfo, FlightController } from '@/types/autopilot'
 
 @Module({
   dynamic: true,
@@ -19,6 +19,8 @@ class AutopilotManagerStore extends VuexModule {
   available_boards: FlightController[] = []
 
   current_board: FlightController | null = null
+
+  firmware_info: FirmwareInfo | null = null
 
   updating_endpoints = true
 
@@ -39,6 +41,11 @@ class AutopilotManagerStore extends VuexModule {
   @Mutation
   setCurrentBoard(board: FlightController | null): void {
     this.current_board = board
+  }
+
+  @Mutation
+  setFirmwareInfo(firmware_info: FirmwareInfo | null): void {
+    this.firmware_info = firmware_info
   }
 
   @Mutation

--- a/core/frontend/src/types/autopilot.ts
+++ b/core/frontend/src/types/autopilot.ts
@@ -1,3 +1,5 @@
+import { SemVer } from 'semver'
+
 export interface Firmware {
     name: string
     url: URL
@@ -53,4 +55,17 @@ export interface FlightController {
   manufacturer: string
   platform: Platform
   path: string
+}
+
+export enum FirmwareType {
+  DEV = 'DEV',
+  ALPHA = 'ALPHA',
+  BETA = 'BETA',
+  RC = 'RC',
+  STABLE = 'STABLE',
+}
+
+export interface FirmwareInfo {
+  version: SemVer
+  type: FirmwareType
 }

--- a/core/frontend/src/utils/api.ts
+++ b/core/frontend/src/utils/api.ts
@@ -1,4 +1,4 @@
-import axios from 'axios'
+import axios, { AxiosInstance } from 'axios'
 
 import frontend from '@/store/frontend'
 
@@ -6,7 +6,7 @@ const backend_offline_error = new Error('Backend is offline')
 backend_offline_error.name = 'BackendOffline'
 export { backend_offline_error }
 
-const axios_backend_instance = axios.create()
+const axios_backend_instance: AxiosInstance = axios.create()
 
 axios_backend_instance.interceptors.request.use(async (config) => {
   // Check if there's already a backend status request running. If yes, use it. If not, start one.

--- a/core/frontend/src/views/GeneralAutopilot.vue
+++ b/core/frontend/src/views/GeneralAutopilot.vue
@@ -15,6 +15,10 @@
         <span class="font-weight-bold">Mavlink platform: </span>
         <span>{{ current_board.platform }}</span>
         <br>
+        <span class="font-weight-bold">Firmware version: </span>
+        <span v-if="firmware_info === null">Unknown</span>
+        <span v-else>{{ firmware_info.version }} ({{ firmware_info.type }})</span>
+        <br>
         <span
           v-if="current_board.path"
           class="font-weight-bold"
@@ -75,7 +79,7 @@ import BoardChangeDialog from '@/components/autopilot/BoardChangeDialog.vue'
 import settings from '@/libs/settings'
 import autopilot from '@/store/autopilot_manager'
 import notifications from '@/store/notifications'
-import { FlightController } from '@/types/autopilot'
+import { FirmwareInfo, FlightController } from '@/types/autopilot'
 import { autopilot_service } from '@/types/frontend_services'
 import back_axios from '@/utils/api'
 
@@ -93,6 +97,9 @@ export default Vue.extend({
   computed: {
     current_board(): FlightController | null {
       return autopilot.current_board
+    },
+    firmware_info(): FirmwareInfo | null {
+      return autopilot.firmware_info
     },
     board_undefined(): boolean {
       return this.current_board === null

--- a/core/frontend/src/views/GeneralAutopilot.vue
+++ b/core/frontend/src/views/GeneralAutopilot.vue
@@ -3,10 +3,28 @@
     class="main-manager"
   >
     <v-card-title>Autopilot</v-card-title>
-    <v-card-subtitle>
+    <v-card-text>
       <span v-if="board_undefined">No board running</span>
-      <span v-else>Currently running: '{{ current_board.name }}'</span>
-    </v-card-subtitle>
+      <div v-else>
+        <span class="font-weight-bold">Board name: </span>
+        <span>{{ current_board.name }}</span>
+        <br>
+        <span class="font-weight-bold">Manufacturer: </span>
+        <span>{{ current_board.manufacturer }}</span>
+        <br>
+        <span class="font-weight-bold">Mavlink platform: </span>
+        <span>{{ current_board.platform }}</span>
+        <br>
+        <span
+          v-if="current_board.path"
+          class="font-weight-bold"
+        >
+          Path:
+        </span>
+        <span>{{ current_board.path }}</span>
+        <br>
+      </div>
+    </v-card-text>
     <v-card-actions class="d-flex justify-end align-center flex-wrap">
       <v-spacer />
       <v-btn

--- a/core/frontend/src/views/GeneralAutopilot.vue
+++ b/core/frontend/src/views/GeneralAutopilot.vue
@@ -19,6 +19,9 @@
         <span v-if="firmware_info === null">Unknown</span>
         <span v-else>{{ firmware_info.version }} ({{ firmware_info.type }})</span>
         <br>
+        <span class="font-weight-bold">Vehicle type: </span>
+        <span>{{ vehicle_type }}</span>
+        <br>
         <span
           v-if="current_board.path"
           class="font-weight-bold"
@@ -100,6 +103,9 @@ export default Vue.extend({
     },
     firmware_info(): FirmwareInfo | null {
       return autopilot.firmware_info
+    },
+    vehicle_type(): string | null {
+      return autopilot.vehicle_type
     },
     board_undefined(): boolean {
       return this.current_board === null

--- a/core/libs/commonwealth/commonwealth/mavlink_comm/MavlinkComm.py
+++ b/core/libs/commonwealth/commonwealth/mavlink_comm/MavlinkComm.py
@@ -19,7 +19,6 @@ class MavlinkMessenger:
         self.component_id = int(os.environ.get("MAV_COMPONENT_ID_ONBOARD_COMPUTER4", 194))
         self.sequence = 0
         self.m2r_address = "localhost:6040"
-        self.m2r_rest_url = f"http://{self.m2r_address}/mavlink"
 
     def set_system_id(self, system_id: int) -> None:
         self.system_id = system_id
@@ -34,7 +33,10 @@ class MavlinkMessenger:
         if len(address.split(":")) != 2:
             raise ValueError("Invalid address. Valid address should follow the format 'localhost:6040'.")
         self.m2r_address = address
-        self.m2r_rest_url = f"http://{self.m2r_address}/mavlink"
+
+    @property
+    def m2r_rest_url(self) -> str:
+        return f"http://{self.m2r_address}/mavlink"
 
     async def get_mavlink_message(
         self, message_name: Optional[str] = None, vehicle: Optional[int] = 1, component: Optional[int] = 1

--- a/core/libs/commonwealth/commonwealth/mavlink_comm/VehicleManager.py
+++ b/core/libs/commonwealth/commonwealth/mavlink_comm/VehicleManager.py
@@ -8,6 +8,7 @@ from commonwealth.mavlink_comm.typedefs import (
     FirmwareInfo,
     FirmwareVersionType,
     MavlinkMessageId,
+    MavlinkVehicleType,
 )
 
 MAV_MODE_FLAG_SAFETY_ARMED = 128
@@ -64,6 +65,10 @@ class VehicleManager:
         version_type = FirmwareVersionType.from_value(version_type_raw)
 
         return FirmwareInfo(version=firmware_version, type=version_type)
+
+    async def get_vehicle_type(self) -> MavlinkVehicleType:
+        heartbeat_message = await self.mavlink2rest.get_updated_mavlink_message("HEARTBEAT")
+        return MavlinkVehicleType[heartbeat_message["message"]["mavtype"]["type"]]  # type: ignore
 
     async def reboot_vehicle(self) -> None:
         message = self.command_long_message("MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN", [1.0])

--- a/core/libs/commonwealth/commonwealth/mavlink_comm/VehicleManager.py
+++ b/core/libs/commonwealth/commonwealth/mavlink_comm/VehicleManager.py
@@ -49,6 +49,14 @@ class VehicleManager:
         shutdown_message = self.command_long_message("MAV_CMD_PREFLIGHT_REBOOT_SHUTDOWN", [2.0])
         await self.mavlink2rest.send_mavlink_message(shutdown_message)
 
+    async def is_heart_beating(self) -> bool:
+        try:
+            await self.mavlink2rest.get_updated_mavlink_message("HEARTBEAT")
+            return True
+        except Exception as error:
+            logger.error(f"Failed to check heartbeat. {error}")
+            return False
+
     async def is_vehicle_armed(self) -> bool:
         get_response = await self.mavlink2rest.get_updated_mavlink_message("HEARTBEAT")
         base_mode_bits = get_response["message"]["base_mode"]["bits"]

--- a/core/libs/commonwealth/commonwealth/mavlink_comm/VehicleManager.py
+++ b/core/libs/commonwealth/commonwealth/mavlink_comm/VehicleManager.py
@@ -63,12 +63,8 @@ class VehicleManager:
             logger.debug("Vehicle already disarmed.")
             return
 
-        logger.debug("Trying to disarm vehicle.")
-
         disarm_message = self.command_long_message("MAV_CMD_COMPONENT_ARM_DISARM", [])
 
         await self.mavlink2rest.send_mavlink_message(disarm_message)
         if await self.is_vehicle_armed():
             raise VehicleDisarmFail("Failed to disarm vehicle. Please try a manual disarm.")
-
-        logger.debug("Successfully disarmed vehicle.")

--- a/core/libs/commonwealth/commonwealth/mavlink_comm/typedefs.py
+++ b/core/libs/commonwealth/commonwealth/mavlink_comm/typedefs.py
@@ -1,0 +1,31 @@
+from enum import Enum
+
+from pydantic import BaseModel
+
+
+class FirmwareVersionType(str, Enum):
+    DEV = "DEV"
+    ALPHA = "ALPHA"
+    BETA = "BETA"
+    RC = "RC"
+    STABLE = "STABLE"
+
+    @staticmethod
+    def from_value(firmware_value: int) -> "FirmwareVersionType":
+        return {
+            0: FirmwareVersionType.DEV,
+            64: FirmwareVersionType.ALPHA,
+            128: FirmwareVersionType.BETA,
+            192: FirmwareVersionType.RC,
+            255: FirmwareVersionType.STABLE,
+        }[firmware_value]
+
+
+class FirmwareInfo(BaseModel):
+    version: str
+    type: FirmwareVersionType
+
+
+class MavlinkMessageId(Enum):
+    HEARTBEAT = 0
+    AUTOPILOT_VERSION = 148

--- a/core/libs/commonwealth/commonwealth/mavlink_comm/typedefs.py
+++ b/core/libs/commonwealth/commonwealth/mavlink_comm/typedefs.py
@@ -21,6 +21,52 @@ class FirmwareVersionType(str, Enum):
         }[firmware_value]
 
 
+class MavlinkVehicleType(str, Enum):
+    MAV_TYPE_GENERIC = "Generic"
+    MAV_TYPE_FIXED_WING = "Fixed Wing"
+    MAV_TYPE_QUADROTOR = "Quadrotor"
+    MAV_TYPE_COAXIAL = "Coaxial"
+    MAV_TYPE_HELICOPTER = "Helicopter"
+    MAV_TYPE_ANTENNA_TRACKER = "Antenna Tracker"
+    MAV_TYPE_GCS = "Gcs"
+    MAV_TYPE_AIRSHIP = "Airship"
+    MAV_TYPE_FREE_BALLOON = "Free Balloon"
+    MAV_TYPE_ROCKET = "Rocket"
+    MAV_TYPE_GROUND_ROVER = "Ground Rover"
+    MAV_TYPE_SURFACE_BOAT = "Surface Boat"
+    MAV_TYPE_SUBMARINE = "Submarine"
+    MAV_TYPE_HEXAROTOR = "Hexarotor"
+    MAV_TYPE_OCTOROTOR = "Octorotor"
+    MAV_TYPE_TRICOPTER = "Tricopter"
+    MAV_TYPE_FLAPPING_WING = "Flapping Wing"
+    MAV_TYPE_KITE = "Kite"
+    MAV_TYPE_ONBOARD_CONTROLLER = "Onboard Controller"
+    MAV_TYPE_VTOL_DUOROTOR = "Vtol (Duorotor)"
+    MAV_TYPE_VTOL_QUADROTOR = "Vtol (Quadrotor)"
+    MAV_TYPE_VTOL_TILTROTOR = "Vtol (Tiltrotor)"
+    MAV_TYPE_VTOL_FIXEDROTOR = "Vtol (Fixedrotor)"
+    MAV_TYPE_VTOL_TAILSITTER = "Vtol (Tailsitter)"
+    MAV_TYPE_VTOL_RESERVED4 = "Vtol (Reserved4)"
+    MAV_TYPE_VTOL_RESERVED5 = "Vtol (Reserved5)"
+    MAV_TYPE_GIMBAL = "Gimbal"
+    MAV_TYPE_ADSB = "Adsb"
+    MAV_TYPE_PARAFOIL = "Parafoil"
+    MAV_TYPE_DODECAROTOR = "Dodecarotor"
+    MAV_TYPE_CAMERA = "Camera"
+    MAV_TYPE_CHARGING_STATION = "Charging Station"
+    MAV_TYPE_FLARM = "Flarm"
+    MAV_TYPE_SERVO = "Servo"
+    MAV_TYPE_ODID = "Odid"
+    MAV_TYPE_DECAROTOR = "Decarotor"
+    MAV_TYPE_BATTERY = "Battery"
+    MAV_TYPE_PARACHUTE = "Parachute"
+    MAV_TYPE_LOG = "Log"
+    MAV_TYPE_OSD = "Osd"
+    MAV_TYPE_IMU = "Imu"
+    MAV_TYPE_GPS = "Gps"
+    MAV_TYPE_WINCH = "Winch"
+
+
 class FirmwareInfo(BaseModel):
     version: str
     type: FirmwareVersionType

--- a/core/libs/commonwealth/setup.py
+++ b/core/libs/commonwealth/setup.py
@@ -20,6 +20,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     python_requires=">=3.9",
     install_requires=[
+        "aiohttp == 3.7.4",
         "appdirs == 1.4.4",
         "loguru == 0.5.3",
         "starlette == 0.13.6",

--- a/core/libs/install-libs.sh
+++ b/core/libs/install-libs.sh
@@ -3,8 +3,26 @@
 # Immediately exit on errors
 set -e
 
+BUILD_PACKAGES=(
+    g++
+)
+
+apt update
+apt install -y --no-install-recommends ${BUILD_PACKAGES[*]}
+
+# Pre-Build dependencies:
+# For convenience, we build ourselves the .wheel packages for dependencies
+# which have no armv7 wheel in pypi. This saves a lot of build time in docker
+if [[ "$(uname -m)" == "armv7l"* ]]; then
+    pip install https://s3.amazonaws.com/downloads.bluerobotics.com/companion-docker/wheels/aiohttp-3.7.4-cp39-cp39-linux_armv7l.whl
+fi
+
 CURRENT_PATH=$(dirname "$0")
 
 # Install libraries
 python3 $CURRENT_PATH/bridges/setup.py install
 python3 $CURRENT_PATH/commonwealth/setup.py install
+
+apt -y remove ${BUILD_PACKAGES[*]}
+apt -y autoremove
+apt -y clean

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -347,7 +347,7 @@ class ArduPilotManager(metaclass=Singleton):
         if not self.current_board or self.current_board.platform != Platform.SITL:
             try:
                 logger.info("Disarming vehicle.")
-                self.vehicle_manager.disarm_vehicle()
+                await self.vehicle_manager.disarm_vehicle()
                 logger.info("Vehicle disarmed.")
             except Exception as error:
                 logger.warning(f"Could not disarm vehicle: {error}. Proceeding with kill.")
@@ -381,7 +381,7 @@ class ArduPilotManager(metaclass=Singleton):
             await self.kill_ardupilot()
             await self.start_ardupilot()
             return
-        self.vehicle_manager.reboot_vehicle()
+        await self.vehicle_manager.reboot_vehicle()
 
     def _get_configuration_endpoints(self) -> Set[Endpoint]:
         return {Endpoint(**endpoint) for endpoint in self.configuration.get("endpoints") or []}

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -7,6 +7,7 @@ import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Set
 
+from commonwealth.mavlink_comm.typedefs import FirmwareInfo
 from commonwealth.utils.apis import GenericErrorHandlingRoute, PrettyJSONResponse
 from commonwealth.utils.general import is_running_as_root
 from commonwealth.utils.logs import InterceptHandler, get_new_log_path
@@ -69,6 +70,14 @@ def remove_endpoints(endpoints: Set[Endpoint] = Body(...)) -> Any:
 @version(1, 0)
 def update_endpoints(endpoints: Set[Endpoint] = Body(...)) -> Any:
     autopilot.update_endpoints(endpoints)
+
+
+@app.get("/firmware_info", response_model=FirmwareInfo, summary="Get version and type of current firmware.")
+@version(1, 0)
+async def get_firmware_info() -> Any:
+    if not autopilot.current_board:
+        raise RuntimeError("Cannot fetch firmware info as there's no board running.")
+    return await autopilot.vehicle_manager.get_firmware_info()
 
 
 @app.get(

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -7,7 +7,7 @@ import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Set
 
-from commonwealth.mavlink_comm.typedefs import FirmwareInfo
+from commonwealth.mavlink_comm.typedefs import FirmwareInfo, MavlinkVehicleType
 from commonwealth.utils.apis import GenericErrorHandlingRoute, PrettyJSONResponse
 from commonwealth.utils.general import is_running_as_root
 from commonwealth.utils.logs import InterceptHandler, get_new_log_path
@@ -78,6 +78,14 @@ async def get_firmware_info() -> Any:
     if not autopilot.current_board:
         raise RuntimeError("Cannot fetch firmware info as there's no board running.")
     return await autopilot.vehicle_manager.get_firmware_info()
+
+
+@app.get("/vehicle_type", response_model=MavlinkVehicleType, summary="Get mavlink vehicle type.")
+@version(1, 0)
+async def get_vehicle_type() -> Any:
+    if not autopilot.current_board:
+        raise RuntimeError("Cannot fetch vehicle type info as there's no board running.")
+    return await autopilot.vehicle_manager.get_vehicle_type()
 
 
 @app.get(

--- a/core/services/nmea_injector/TrafficController.py
+++ b/core/services/nmea_injector/TrafficController.py
@@ -51,7 +51,7 @@ class TcpNmeaProtocol(asyncio.Protocol):
         message = data.decode()
         logger.info(f"Message received for component {self._component_id}: {message}")
         mavlink_package = TrafficController.parse_mavlink_package(message)
-        TrafficController.forward_message(mavlink_package, self._component_id)
+        asyncio.run(TrafficController.forward_message(mavlink_package, self._component_id))
         logger.info("Successfully forwarded mavlink coordinates package.")
 
 
@@ -69,7 +69,7 @@ class UdpNmeaProtocol(asyncio.DatagramProtocol):
         message = data.decode()
         logger.info(f"Message received for component {self._component_id}: {message}")
         mavlink_package = TrafficController.parse_mavlink_package(message)
-        TrafficController.forward_message(mavlink_package, self._component_id)
+        asyncio.run(TrafficController.forward_message(mavlink_package, self._component_id))
         logger.info("Successfully forwarded mavlink coordinates package.")
 
 
@@ -113,8 +113,8 @@ class TrafficController:
         return parse_mavlink_from_sentence(nmea_sentence)
 
     @staticmethod
-    def forward_message(message: MavlinkGpsInput, component_id: int) -> None:
+    async def forward_message(message: MavlinkGpsInput, component_id: int) -> None:
         """Forward Mavlink message package to Mavlink2Rest, on the specified component ID."""
         mavlink2rest = MavlinkMessenger()
         mavlink2rest.set_component_id(component_id)
-        mavlink2rest.send_mavlink_message(message.dict())
+        await mavlink2rest.send_mavlink_message(message.dict())


### PR DESCRIPTION
- Make MavlinkComm/VehicleManager async
- Add following info about autopilot:
  - Mavlink platform
  - Board manufacturer
  - Firmware version
  - Vehicle type
  - Path (for serial boards)
- Pre-build/install dependencies before libs and services

<img width="819" alt="image" src="https://user-images.githubusercontent.com/6551040/161164075-5d5a65ac-f71f-4e1c-8610-990faed595ec.png">

I'm thinking about parsing the vehicle-type to be more human-readable and will merge the General and Firmware pages (on this or a following PR).

Fix #458 
Fix #777 
Fix #949 

Image available under `rafaellehmkuhl/blueos-core`