### PR TITLE
Improve system-information design

### DIFF
--- a/core/frontend/src/components/system-information/AboutThisSystem.vue
+++ b/core/frontend/src/components/system-information/AboutThisSystem.vue
@@ -1,10 +1,7 @@
 <template>
   <v-sheet
-    elevation="1"
-    outlined
     shaped
-    class="mx-auto"
-    max-width="500"
+    class="pa-6"
   >
     <v-responsive :aspect-ratio="32/9">
       <v-row justify="center">

--- a/core/frontend/src/components/system-information/AboutThisSystem.vue
+++ b/core/frontend/src/components/system-information/AboutThisSystem.vue
@@ -1,32 +1,25 @@
 <template>
   <v-sheet
     shaped
-    class="pa-6"
+    class="pa-6 d-flex flex-column align-center"
   >
-    <v-responsive :aspect-ratio="32/9">
-      <v-row justify="center">
-        <v-icon
-          size="100"
-        >
-          {{ avatar }}
-        </v-icon>
-        <v-list dense>
-          <v-list-item
-            v-for="(item, i) in info"
-            :key="i"
-            selectable
-          >
-            <v-list-item-icon>
-              <v-icon v-text="item.icon" />
-            </v-list-item-icon>
-            <v-list-item-content>
-              <v-list-item-title v-text="item.title" />
-              <v-list-item-subtitle v-text="item.value" />
-            </v-list-item-content>
-          </v-list-item>
-        </v-list>
-      </v-row>
-    </v-responsive>
+    <v-icon
+      size="100"
+    >
+      {{ avatar }}
+    </v-icon>
+    <v-list dense>
+      <v-list-item
+        v-for="(item, i) in info"
+        :key="i"
+        selectable
+      >
+        <v-list-item-content>
+          <v-list-item-title v-text="item.title" />
+          <v-list-item-subtitle v-text="item.value" />
+        </v-list-item-content>
+      </v-list-item>
+    </v-list>
   </v-sheet>
 </template>
 

--- a/core/frontend/src/components/system-information/AboutThisSystem.vue
+++ b/core/frontend/src/components/system-information/AboutThisSystem.vue
@@ -11,23 +11,19 @@
           {{ avatar }}
         </v-icon>
         <v-list dense>
-          <v-list-item-group
-            color="primary"
+          <v-list-item
+            v-for="(item, i) in info"
+            :key="i"
+            selectable
           >
-            <v-list-item
-              v-for="(item, i) in info"
-              :key="i"
-              selectable
-            >
-              <v-list-item-icon>
-                <v-icon v-text="item.icon" />
-              </v-list-item-icon>
-              <v-list-item-content>
-                <v-list-item-title v-text="item.title" />
-                <v-list-item-subtitle v-text="item.value" />
-              </v-list-item-content>
-            </v-list-item>
-          </v-list-item-group>
+            <v-list-item-icon>
+              <v-icon v-text="item.icon" />
+            </v-list-item-icon>
+            <v-list-item-content>
+              <v-list-item-title v-text="item.title" />
+              <v-list-item-subtitle v-text="item.value" />
+            </v-list-item-content>
+          </v-list-item>
         </v-list>
       </v-row>
     </v-responsive>

--- a/core/frontend/src/components/system-information/Kernel.vue
+++ b/core/frontend/src/components/system-information/Kernel.vue
@@ -6,7 +6,9 @@
           min-height="70vh"
           rounded="lg"
         >
-          <v-card>
+          <v-card
+            elevation="0"
+          >
             <v-virtual-scroll
               :item-height="20"
               :items="messages"

--- a/core/frontend/src/components/system-information/Network.vue
+++ b/core/frontend/src/components/system-information/Network.vue
@@ -1,13 +1,12 @@
 <template>
-  <v-row
-
-    class="ma-5"
+  <v-card
+    flat
+    class="ma-3 d-flex flex-wrap"
   >
     <network-card
       v-for="(network, i) in networks"
       :key="i"
       :network="network"
-      class="ma-5"
     />
     <v-card>
       <v-skeleton-loader
@@ -18,7 +17,7 @@
         type="article, list-item@5"
       />
     </v-card>
-  </v-row>
+  </v-card>
 </template>
 
 <script lang="ts">

--- a/core/frontend/src/components/system-information/NetworkCard.vue
+++ b/core/frontend/src/components/system-information/NetworkCard.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card
-    class="mx-auto"
-    min-width="400"
+    class="ma-3"
+    min-width="340"
   >
     <v-list-item two-line>
       <v-list-item-content>

--- a/core/frontend/src/components/system-information/Processes.vue
+++ b/core/frontend/src/components/system-information/Processes.vue
@@ -3,7 +3,7 @@
     dense
     :headers="filteredHeader"
     :items="process"
-    class="elevation-1 pa-3"
+    class="pa-6"
     item-key="pid"
     :items-per-page="-1"
     :sort-by="['cpu_usage']"

--- a/core/frontend/src/components/system-information/SystemCondition.vue
+++ b/core/frontend/src/components/system-information/SystemCondition.vue
@@ -3,7 +3,7 @@
     <system-condition-card
       v-for="(item, i) in [cpu, memory, disk, temperature]"
       :key="i"
-      class="grow ma-10"
+      class="grow mx-3 my-6"
       :title="item.name"
       :value="item.value"
       :text="item.text"

--- a/core/frontend/src/components/system-information/SystemConditionCard.vue
+++ b/core/frontend/src/components/system-information/SystemConditionCard.vue
@@ -1,6 +1,5 @@
 <template>
   <v-card
-    class="mt-4 mr-4 mx-auto"
     max-width="400"
     min-width="300"
   >

--- a/core/frontend/src/views/SystemInformationView.vue
+++ b/core/frontend/src/views/SystemInformationView.vue
@@ -1,56 +1,49 @@
 <template>
   <v-container
     style="max-width:90%"
+    class="d-flex my-6"
   >
-    <v-row
-      no-gutters
+    <v-card
+      elevation="2"
+      class="mr-4"
     >
-      <v-col
-        md="3"
+      <v-navigation-drawer
+        floating
+        permanent
       >
-        <v-card
-          elevation="2"
-          class="ma-3"
+        <v-list
+          dense
+          rounded
         >
-          <v-navigation-drawer
-            floating
-            permanent
+          <v-list-item
+            v-for="item in pages"
+            :key="item.title"
+            link
+            :input-value="item.value == page_selected"
+            @click="page_selected=item.value"
           >
-            <v-list
-              dense
-              rounded
-            >
-              <v-list-item
-                v-for="item in pages"
-                :key="item.title"
-                link
-                :input-value="item.value == page_selected"
-                @click="page_selected=item.value"
-              >
-                <v-list-item-icon>
-                  <v-icon>{{ item.icon }}</v-icon>
-                </v-list-item-icon>
+            <v-list-item-icon>
+              <v-icon>{{ item.icon }}</v-icon>
+            </v-list-item-icon>
 
-                <v-list-item-content>
-                  <v-list-item-title>{{ item.title }}</v-list-item-title>
-                </v-list-item-content>
-              </v-list-item>
-            </v-list>
-          </v-navigation-drawer>
-        </v-card>
-      </v-col>
+            <v-list-item-content>
+              <v-list-item-title>{{ item.title }}</v-list-item-title>
+            </v-list-item-content>
+          </v-list-item>
+        </v-list>
+      </v-navigation-drawer>
+    </v-card>
 
-      <v-col
-        v-if="true"
-        md="9"
-      >
-        <processes v-if="page_selected == 'process'" />
-        <system-condition v-if="page_selected == 'system_condition'" />
-        <network v-if="page_selected == 'network'" />
-        <kernel v-if="page_selected == 'kernel'" />
-        <about-this-system v-if="page_selected == 'about'" />
-      </v-col>
-    </v-row>
+    <v-card
+      elevation="2"
+      width="100%"
+    >
+      <processes v-if="page_selected == 'process'" />
+      <system-condition v-if="page_selected == 'system_condition'" />
+      <network v-if="page_selected == 'network'" />
+      <kernel v-if="page_selected == 'kernel'" />
+      <about-this-system v-if="page_selected == 'about'" />
+    </v-card>
   </v-container>
 </template>
 


### PR DESCRIPTION
Before/after

![image](https://user-images.githubusercontent.com/6551040/162045830-afe05146-500a-4346-8cf2-e650db667fe1.png)
![image](https://user-images.githubusercontent.com/6551040/162046053-181feaf2-f932-495c-a304-cb11900b0e48.png)

![image](https://user-images.githubusercontent.com/6551040/162046256-2926b908-ad7f-4a39-925c-7657f6714774.png)
![image](https://user-images.githubusercontent.com/6551040/162046191-178251e8-e787-4623-8bf1-042c0ee2b75c.png)


All the available system-info pages had similar improvements.

Fix #955 
Fix #956 