### PR TITLE
core: frontend: remove lazi-loading from iframes

### DIFF
--- a/core/frontend/src/components/utils/iframe.vue
+++ b/core/frontend/src/components/utils/iframe.vue
@@ -9,7 +9,6 @@
     />
     <iframe
       v-show="iframe_loaded"
-      loading="lazy"
       :src="source"
       height="100%"
       width="100%"


### PR DESCRIPTION
Fixes the issue of opening iframes from some domains. not sure why.

proper test image will be up at williangalvani/blueos-core:no-lazyness after CI is done