### PR TITLE
frontend: Use chaining operator on all `error.response.data` calls

### DIFF
--- a/core/frontend/src/components/app/PowerMenu.vue
+++ b/core/frontend/src/components/app/PowerMenu.vue
@@ -185,7 +185,7 @@ export default Vue.extend({
           if (error.code === 'ECONNABORTED') {
             return
           }
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: commander_service, type: 'SHUTDOWN_FAIL', message })
         })
     },

--- a/core/frontend/src/components/app/SettingsMenu.vue
+++ b/core/frontend/src/components/app/SettingsMenu.vue
@@ -109,7 +109,7 @@ export default Vue.extend({
           this.show_reset_dialog = true
         })
         .catch((error) => {
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: commander_service, type: 'RESET_SETTINGS_FAIL', message })
         })
     },

--- a/core/frontend/src/components/autopilot/AutopilotManagerUpdater.vue
+++ b/core/frontend/src/components/autopilot/AutopilotManagerUpdater.vue
@@ -39,7 +39,7 @@ export default Vue.extend({
         .catch((error) => {
           autopilot.setAvailableEndpoints([])
           if (error === backend_offline_error) { return }
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_ENDPOINT_FETCH_FAIL', message })
         })
     },
@@ -56,7 +56,7 @@ export default Vue.extend({
         .catch((error) => {
           autopilot.setAvailableBoards([])
           if (error === backend_offline_error) { return }
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_BOARDS_FETCH_FAIL', message })
         })
     },
@@ -72,7 +72,7 @@ export default Vue.extend({
         .catch((error) => {
           autopilot.setCurrentBoard(null)
           if (error === backend_offline_error) { return }
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_BOARD_FETCH_FAIL', message })
         })
     },

--- a/core/frontend/src/components/autopilot/EndpointCard.vue
+++ b/core/frontend/src/components/autopilot/EndpointCard.vue
@@ -198,7 +198,7 @@ export default Vue.extend({
         data: [this.endpoint],
       })
         .catch((error) => {
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_ENDPOINT_DELETE_FAIL', message })
         })
     },
@@ -215,7 +215,7 @@ export default Vue.extend({
         data: [this.updated_endpoint],
       })
         .catch((error) => {
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_ENDPOINT_UPDATE_FAIL', message })
         })
     },

--- a/core/frontend/src/components/autopilot/EndpointCreationDialog.vue
+++ b/core/frontend/src/components/autopilot/EndpointCreationDialog.vue
@@ -160,7 +160,7 @@ export default Vue.extend({
           this.form.reset()
         })
         .catch((error) => {
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_ENDPOINT_CREATE_FAIL', message })
         })
       return true

--- a/core/frontend/src/components/autopilot/FirmwareManager.vue
+++ b/core/frontend/src/components/autopilot/FirmwareManager.vue
@@ -272,7 +272,7 @@ export default Vue.extend({
         .catch((error) => {
           this.cloud_firmware_options_status = CloudFirmwareOptionsStatus.FetchFailed
           if (error === backend_offline_error) { return }
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'FIRMWARE_FETCH_FAIL', message })
         })
     },
@@ -327,7 +327,7 @@ export default Vue.extend({
           if (error.message && error.message === 'Network Error') {
             this.install_result_message = 'Upload fail. If the file was changed, clean the form and re-select it.'
           } else {
-            this.install_result_message = error.response.data.detail ?? error.message
+            this.install_result_message = error.response?.data?.detail ?? error.message
           }
           const message = `Could not install firmware: ${this.install_result_message}.`
           notifications.pushError({ service: autopilot_service, type: 'FILE_FIRMWARE_INSTALL_FAIL', message })

--- a/core/frontend/src/components/bridges/BridgeCard.vue
+++ b/core/frontend/src/components/bridges/BridgeCard.vue
@@ -64,7 +64,7 @@ export default Vue.extend({
         data: this.bridge,
       })
         .catch((error) => {
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: bridget_service, type: 'BRIDGE_DELETE_FAIL', message })
         })
     },

--- a/core/frontend/src/components/bridges/BridgeCreationDialog.vue
+++ b/core/frontend/src/components/bridges/BridgeCreationDialog.vue
@@ -153,7 +153,7 @@ export default Vue.extend({
           this.form.reset()
         })
         .catch((error) => {
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: bridget_service, type: 'BRIDGE_CREATE_FAIL', message })
         })
       return true

--- a/core/frontend/src/components/ethernet/AddressCreationDialog.vue
+++ b/core/frontend/src/components/ethernet/AddressCreationDialog.vue
@@ -102,7 +102,7 @@ export default Vue.extend({
           this.form.reset()
         })
         .catch((error) => {
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: ethernet_service, type: 'ETHERNET_ADDRESS_CREATION_FAIL', message })
         })
       return true

--- a/core/frontend/src/components/ethernet/DHCPServerDialog.vue
+++ b/core/frontend/src/components/ethernet/DHCPServerDialog.vue
@@ -135,7 +135,7 @@ export default Vue.extend({
           this.connection_result_message = 'Successfully enabled DHCP server.'
         })
         .catch((error) => {
-          const message = error.response.data.detail ? error.response.data.detail : error.message
+          const message = error.response?.data?.detail ? error.response?.data?.detail : error.message
           this.connection_result_message = message
           notifications.pushError({ service: ethernet_service, type: 'DHCP_SERVER_ADD_FAIL', message })
         })

--- a/core/frontend/src/components/ethernet/EthernetUpdater.vue
+++ b/core/frontend/src/components/ethernet/EthernetUpdater.vue
@@ -29,7 +29,7 @@ export default Vue.extend({
         .catch((error) => {
           ethernet.setInterfaces([])
           if (error === backend_offline_error) { return }
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: ethernet_service, type: 'ETHERNET_AVAILABLE_FETCH_FAIL', message })
         })
     },

--- a/core/frontend/src/components/ethernet/InterfaceCard.vue
+++ b/core/frontend/src/components/ethernet/InterfaceCard.vue
@@ -147,7 +147,7 @@ export default Vue.extend({
         params: { interface_name: this.adapter.name, ip_address: ip },
       })
         .catch((error) => {
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: ethernet_service, type: 'ETHERNET_ADDRESS_DELETE_FAIL', message })
         })
     },

--- a/core/frontend/src/components/nmea-injector/NMEAInjectorUpdater.vue
+++ b/core/frontend/src/components/nmea-injector/NMEAInjectorUpdater.vue
@@ -37,7 +37,7 @@ export default Vue.extend({
         .catch((error) => {
           nmea_injector.setAvailableNMEASockets([])
           if (error === backend_offline_error) { return }
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: nmea_injector_service, type: 'BRIDGES_FETCH_FAIL', message })
         })
         .finally(() => {

--- a/core/frontend/src/components/nmea-injector/NMEASocketCard.vue
+++ b/core/frontend/src/components/nmea-injector/NMEASocketCard.vue
@@ -64,7 +64,7 @@ export default Vue.extend({
         data: this.nmeaSocket,
       })
         .catch((error) => {
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: nmea_injector_service, type: 'nmeaSocket_DELETE_FAIL', message })
         })
     },

--- a/core/frontend/src/components/nmea-injector/NMEASocketCreationDialog.vue
+++ b/core/frontend/src/components/nmea-injector/NMEASocketCreationDialog.vue
@@ -134,7 +134,7 @@ export default Vue.extend({
           this.form.reset()
         })
         .catch((error) => {
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: nmea_injector_service, type: 'NMEA_SOCKET_CREATE_FAIL', message })
         })
       return true

--- a/core/frontend/src/components/version-chooser/VersionChooser.vue
+++ b/core/frontend/src/components/version-chooser/VersionChooser.vue
@@ -487,7 +487,7 @@ export default Vue.extend({
           (element) => element.repository !== repository || element.tag !== tag,
         )
       })
-        .catch((error) => { alert(error.response.data) })
+        .catch((error) => { alert(error.response?.data ?? error.message) })
         .finally(() => { this.deleting = '' })
     },
     imageIsAvailableLocally(sha: string) : boolean {

--- a/core/frontend/src/components/wifi/ConnectionDialog.vue
+++ b/core/frontend/src/components/wifi/ConnectionDialog.vue
@@ -233,7 +233,7 @@ export default Vue.extend({
         })
         .catch((error) => {
           this.connection_status = ConnectionStatus.Failed
-          let message = error.response.data.detail ?? error.message
+          let message = error.response?.data?.detail ?? error.message
           message = message.concat('\n', 'Please check if the password is correct.')
           this.connection_result_message = message
           notifications.pushError({ service: wifi_service, type: 'WIFI_CONNECT_FAIL', message })
@@ -247,7 +247,7 @@ export default Vue.extend({
         params: { ssid: this.network.ssid },
       })
         .catch((error) => {
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: wifi_service, type: 'WIFI_FORGET_FAIL', message })
         })
         .finally(() => {

--- a/core/frontend/src/store/bridget.ts
+++ b/core/frontend/src/store/bridget.ts
@@ -86,7 +86,7 @@ class BridgetStore extends VuexModule {
       .catch((error) => {
         this.setAvailableBridges([])
         if (error === backend_offline_error) { return }
-        const message = error.response.data.detail ?? error.message
+        const message = error.response?.data?.detail ?? error.message
         notifications.pushError({ service: bridget_service, type: 'BRIDGES_FETCH_FAIL', message })
       })
       .finally(() => {
@@ -112,7 +112,7 @@ class BridgetStore extends VuexModule {
       .catch((error) => {
         this.setAvailableSerialPorts([])
         if (error === backend_offline_error) { return }
-        const message = error.response.data.detail ?? error.message
+        const message = error.response?.data?.detail ?? error.message
         notifications.pushError({ service: bridget_service, type: 'BRIDGET_SERIAL_PORTS_FETCH_FAIL', message })
       })
       .finally(() => {

--- a/core/frontend/src/store/video.ts
+++ b/core/frontend/src/store/video.ts
@@ -74,7 +74,7 @@ class VideoStore extends VuexModule {
       .then(() => true)
       .catch((error) => {
         if (error === backend_offline_error) { return false }
-        const message = `Could not create video stream: ${error.message}. ${error.response.data}.`
+        const message = `Could not create video stream: ${error.response?.data ?? error.message}.`
         error_message_manager.emitMessage(message)
         notifications.pushError({ service: video_manager_service, type: 'VIDEO_STREAM_CREATION_FAIL', message })
         return false

--- a/core/frontend/src/utils/update_time.ts
+++ b/core/frontend/src/utils/update_time.ts
@@ -21,7 +21,7 @@ export default async function run() : Promise<void> {
         return
       }
 
-      const message = error.response.data.detail ?? error.message
+      const message = error.response?.data?.detail ?? error.message
       notifications.pushError({ service: update_time_service, type: 'UPDATE_TIME_FAIL', message })
     })
 }

--- a/core/frontend/src/views/GeneralAutopilot.vue
+++ b/core/frontend/src/views/GeneralAutopilot.vue
@@ -92,7 +92,7 @@ export default Vue.extend({
         timeout: 10000,
       })
         .catch((error) => {
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_START_FAIL', message })
         })
         .finally(() => {
@@ -107,7 +107,7 @@ export default Vue.extend({
         timeout: 10000,
       })
         .catch((error) => {
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_STOP_FAIL', message })
         })
         .finally(() => {
@@ -122,7 +122,7 @@ export default Vue.extend({
         timeout: 10000,
       })
         .catch((error) => {
-          const message = error.response.data.detail ?? error.message
+          const message = error.response?.data?.detail ?? error.message
           notifications.pushError({ service: autopilot_service, type: 'AUTOPILOT_RESTART_FAIL', message })
         })
         .finally(() => {


### PR DESCRIPTION
Use `error.response?.data ?? error.message` instead

With this, we catch two situations:
1. Error is not of HTTP type and does not have a response property
2. Error is of HTTP type but does not have a payload (data)

In both situations javascript would throw and, if such expression was on an auto-updater, for example, the auto-updater would die.

This happened when, for example, a timeout occurs.