### PR TITLE
core: nginx: fix 2770 -> 80 redirect

### DIFF
--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -34,7 +34,7 @@ http {
         listen 2770;
 
         location / {
-            rewrite ^/(.*)$ http://(blueos|companion).local redirect;
+            rewrite ^/(.*)$ http://$host redirect;
         }
     }
 


### PR DESCRIPTION
this redirects 192.168.2.2:2770 to 192.168.2.2.
ideally we should redirect it to "blueos.local" or whatever the current name is, but I don't think we can fetch that name from nginx yet...

We could use beacon in the frontend to choose a domain and redirect to it

fix #632 