### PR TITLE
Integrate error-alert with Notifier

### DIFF
--- a/core/frontend/src/libs/notifier.ts
+++ b/core/frontend/src/libs/notifier.ts
@@ -13,23 +13,23 @@ class Notifier {
   }
 
   pushSuccess(type: string, message: string): void {
-    notifications.pushNotification(new LiveNotification(NotificationLevel.Success, this.service, type, message))
+    this.push(NotificationLevel.Success, type, message)
   }
 
   pushError(type: string, message: string): void {
-    notifications.pushNotification(new LiveNotification(NotificationLevel.Error, this.service, type, message))
+    this.push(NotificationLevel.Error, type, message)
   }
 
   pushInfo(type: string, message: string): void {
-    notifications.pushNotification(new LiveNotification(NotificationLevel.Info, this.service, type, message))
+    this.push(NotificationLevel.Info, type, message)
   }
 
   pushWarning(type: string, message: string): void {
-    notifications.pushNotification(new LiveNotification(NotificationLevel.Warning, this.service, type, message))
+    this.push(NotificationLevel.Warning, type, message)
   }
 
   pushCritical(type: string, message: string): void {
-    notifications.pushNotification(new LiveNotification(NotificationLevel.Critical, this.service, type, message))
+    this.push(NotificationLevel.Critical, type, message)
   }
 
   pushBackError(type: string, error: any): void {

--- a/core/frontend/src/libs/notifier.ts
+++ b/core/frontend/src/libs/notifier.ts
@@ -1,3 +1,4 @@
+import error_message_manager from '@/libs/error-message'
 import notifications from '@/store/notifications'
 import { Service } from '@/types/common'
 import { LiveNotification, NotificationLevel } from '@/types/notifications'
@@ -16,7 +17,8 @@ class Notifier {
     this.push(NotificationLevel.Success, type, message)
   }
 
-  pushError(type: string, message: string): void {
+  pushError(type: string, message: string, alert = false): void {
+    if (alert) { error_message_manager.emitMessage(message) }
     this.push(NotificationLevel.Error, type, message)
   }
 
@@ -32,10 +34,10 @@ class Notifier {
     this.push(NotificationLevel.Critical, type, message)
   }
 
-  pushBackError(type: string, error: any): void {
+  pushBackError(type: string, error: any, alert = false): void {
     if (error === backend_offline_error) { return }
     const message = error.response?.data?.detail ?? error.message
-    this.pushError(type, message)
+    this.pushError(type, message, alert)
   }
 }
 

--- a/core/frontend/src/libs/notifier.ts
+++ b/core/frontend/src/libs/notifier.ts
@@ -1,8 +1,6 @@
 import notifications from '@/store/notifications'
 import { Service } from '@/types/common'
-import {
-  CumulatedNotification, LiveNotification, Notification, NotificationLevel,
-} from '@/types/notifications'
+import { LiveNotification, NotificationLevel } from '@/types/notifications'
 import { backend_offline_error } from '@/utils/api'
 
 class Notifier {


### PR DESCRIPTION
Adds possibility of emitting an alert when pushing error notifications.
This is mostly useful for giving feedback on user actions (e.g.: someone trying to add an endpoint, but the backend rejects for duplicity).

Image available.