### PR TITLE
core: Add initial 3rd party integration

### DIFF
--- a/core/frontend/src/types/helper.ts
+++ b/core/frontend/src/types/helper.ts
@@ -1,7 +1,18 @@
+export interface ServiceMetadata {
+    name: string
+    description: string
+    icon: string
+    company: string
+    version: string
+    webpage: string
+    api: string
+}
+
 export interface Service {
     valid: boolean
     title: string
     documentation_url: string
     versions: Array<string>
     port: number
+    metadata?: ServiceMetadata
 }


### PR DESCRIPTION
This follows our documentation described in the wiki page
To test:
create the following file in a path: `register_service`
content:
```js
{
    "name":"Extension name",
    "description":"A small description about the service",
    "icon":"mdi-alpha-p-box",
    "company":"Blue Robotics",
    "version":"1.2.0",
    "webpage":"https://github.com/bluerobotics/BlueOS-docker",
    "api":""
 }
```
start simple python http server:
`python3 -m http.server 9992`

docker: patrickelectric/blueos-core:add_3rd_party_integration