### PR TITLE
frontend: notifications: Use on tray icon number of notifications being displayed

### DIFF
--- a/core/frontend/src/components/notifications/NotificationManager.vue
+++ b/core/frontend/src/components/notifications/NotificationManager.vue
@@ -113,6 +113,11 @@ export default Vue.extend({
       return notifications_to_show.reverse()
     },
   },
+  watch: {
+    notifications(): void {
+      this.$emit('notificationsChange', this.notifications_to_show)
+    },
+  },
   mounted() {
     const interval = setInterval(this.updateTimestamp, 1000)
     this.active_intervals.push(interval)

--- a/core/frontend/src/components/notifications/TrayButton.vue
+++ b/core/frontend/src/components/notifications/TrayButton.vue
@@ -1,5 +1,6 @@
 <template>
   <v-menu
+    eager
     :close-on-content-click="false"
     nudge-left="500"
     nudge-bottom="30"
@@ -26,14 +27,16 @@
         </v-badge>
       </v-card>
     </template>
-    <notification-manager />
+    <notification-manager
+      @notificationsChange="updateNumberOfNotifications"
+    />
   </v-menu>
 </template>
 
 <script lang="ts">
 import Vue from 'vue'
 
-import notifications from '@/store/notifications'
+import { CumulatedNotification } from '@/types/notifications'
 
 import NotificationManager from './NotificationManager.vue'
 
@@ -42,9 +45,14 @@ export default Vue.extend({
   components: {
     NotificationManager,
   },
-  computed: {
-    number_of_notifications(): number {
-      return notifications.active_cumulated_notifications.length
+  data() {
+    return {
+      number_of_notifications: 0,
+    }
+  },
+  methods: {
+    updateNumberOfNotifications(showable_notifications: CumulatedNotification[]): void {
+      this.number_of_notifications = showable_notifications.length
     },
   },
 })


### PR DESCRIPTION
As before, we were showing on the tray notification icon the number of active notifications.

On the other hand, the notification's manager was showing just recent notifications (from the last minute and limited to 100).

With this change, the manager emits the updated number of notifications it is showing, and the tray icon uses it, so they are in sync.

Tip here: the `eager` property on the `v-menu` component is what makes it instantiate the manager on mount and allow the emit updates to start without the need for the user to click the menu icon.

Fix #953 