### PR TITLE
core: libs: commonwealth: decorators: Fix temporary_cache

### DIFF
--- a/core/libs/commonwealth/commonwealth/utils/decorators.py
+++ b/core/libs/commonwealth/commonwealth/utils/decorators.py
@@ -13,21 +13,21 @@ def temporary_cache(timeout_seconds: float = 10) -> Callable[[Callable[[Any], An
         Any: Return of the decorated function
     """
     cache: Dict[Any, Any] = {}
-    last_sample_time = 0.0
+    last_sample_time: Dict[Any, float] = {}
 
     def inner_function(function: Callable[[Any], Any]) -> Any:
         @wraps(function)
         def wrapper(*args: Any) -> Any:
             nonlocal last_sample_time
             current_time = time.time()
-            cache_is_valid = current_time - last_sample_time < timeout_seconds
+            cache_is_valid = args in last_sample_time and current_time - last_sample_time[args] < timeout_seconds
 
             # The cache is still valid and we can return the value if exists
             if cache_is_valid and args in cache:
                 return cache[args]
 
             # The cache is invalid or argument does not exist in cache, update it!
-            last_sample_time = current_time
+            last_sample_time[args] = current_time
             function_return = function(*args)
             cache[args] = function_return
             return function_return


### PR DESCRIPTION
Cache was global for all inputs and not for each input.
Patch tracks the time per entry now.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>