### PR TITLE
core: versionchooser: cleanup dangling docker images when starting up

### DIFF
--- a/core/services/versionchooser/setup.py
+++ b/core/services/versionchooser/setup.py
@@ -46,6 +46,7 @@ setup(
         "aiohttp-jinja2 == 1.4.2",
         "aiohttp == 3.7.4",
         "aiodocker == 0.21.0",
+        "docker == 5.0.3",
         "jsonschema == 3.2.0",
         "pyrsistent == 0.16.0",
         "connexion[swagger-ui, aiohttp] @ https://github.com/zalando/connexion.git@jsonschema-4.0.0",

--- a/core/services/versionchooser/utils/chooser.py
+++ b/core/services/versionchooser/utils/chooser.py
@@ -1,12 +1,14 @@
 import json
 import logging
 import pathlib
+import sys
 from dataclasses import asdict
 from datetime import datetime
 from typing import Dict, List, Optional, Tuple, Union
 
 import aiodocker
 import appdirs
+import docker
 from aiohttp import web
 
 from utils.dockerhub import TagFetcher, TagMetadata
@@ -24,6 +26,15 @@ logging.basicConfig(level=logging.INFO)
 class VersionChooser:
     def __init__(self, client: aiodocker.Docker):
         self.client = client
+        self.cleanup()
+
+    @staticmethod
+    def cleanup() -> None:
+        if "pytest" in sys.modules:  # don't run this in testing environment
+            return
+        # TODO: migrate this to aiodocker once https://github.com/aio-libs/aiodocker/issues/696 is fixed
+        client = docker.from_env()
+        client.images.prune({"dangling": True})
 
     @staticmethod
     def index() -> web.FileResponse:


### PR DESCRIPTION
we should have a way of cleaning up until https://github.com/aio-libs/aiodocker/issues/696 is closed.