### PR TITLE
ArdupilotManager: launch ardusub with gdbserver if debug symbols are present

### DIFF
--- a/core/services/ardupilot_manager/setup.py
+++ b/core/services/ardupilot_manager/setup.py
@@ -78,6 +78,7 @@ setuptools.setup(
         "starlette == 0.13.6",
         "fastapi == 0.63.0",
         "uvicorn == 0.13.4",
+        "python-magic == 0.4.25",
         "python-multipart == 0.0.5",
         "validators == 0.18.2",
         "fastapi-versioning == 0.9.1",


### PR DESCRIPTION
This means a gdb server will be opened on port 5555 for debugging. ardupilot doesn't start until a debugger is attached.

While I would like to have something in the GUI signalling that we are in debug mode, there is 0% chance that someone will randomly stumble upon a debug build of ardupilot and upload it not knowing what they are doing...

Depends on https://github.com/bluerobotics/companion-docker-base/pull/14

Fix #717