### PR TITLE
Add hotspot functionality

### DIFF
--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -37,7 +37,8 @@
     "vue-tour": "^2.0.0",
     "vuetify": "^2.4.0",
     "vuex": "^3.4.0",
-    "vuex-module-decorators": "^1.0.1"
+    "vuex-module-decorators": "^1.0.1",
+    "wifi-qr-code-generator": "^1.1.1"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.18.0",

--- a/core/frontend/src/components/wifi/WifiManager.vue
+++ b/core/frontend/src/components/wifi/WifiManager.vue
@@ -4,6 +4,39 @@
     width="500"
     max-height="80vh"
   >
+    <v-app-bar elevate-on-scroll>
+      <v-toolbar-title>Wifi</v-toolbar-title>
+      <v-spacer />
+      <v-btn
+        v-tooltip="'Toggle hotspot'"
+        icon
+        :color="hotspot_status ? 'success' : 'gray'"
+        hide-details="auto"
+        :loading="hotspot_status_loading"
+        @click="toggleHotspot"
+      >
+        <v-icon>{{ hotspot_status ? 'mdi-access-point' : 'mdi-access-point-off' }}</v-icon>
+      </v-btn>
+      <v-btn
+        v-tooltip="'WiFi QR Code'"
+        icon
+        color="primary"
+        hide-details="auto"
+        @click="toggleQrCodeDialog"
+      >
+        <v-icon>mdi-qrcode-scan</v-icon>
+      </v-btn>
+      <v-btn
+        v-tooltip="'Settings'"
+        icon
+        color="gray"
+        hide-details="auto"
+        @click="toggleSettingsMenu"
+      >
+        <v-icon>mdi-cog</v-icon>
+      </v-btn>
+    </v-app-bar>
+
     <v-sheet>
       <network-card
         v-if="current_network"
@@ -53,20 +86,50 @@
       :network="current_network"
       :status="wifi_status"
     />
+
+    <wifi-settings-dialog v-model="show_settings_menu" />
+
+    <v-dialog
+      v-model="show_qr_code_dialog"
+      width="300"
+    >
+      <v-card>
+        <v-card-title class="text-h5">
+          Connect to the hotspot
+        </v-card-title>
+        <v-card-text>
+          <div class="d-flex align-center justify-center">
+            <img
+              :src="wifi_qr_code_img"
+              width="200"
+              height="200"
+            >
+          </div>
+          <span>Scan this QR code with your phone to connect to BlueOS's hotspot.</span>
+        </v-card-text>
+      </v-card>
+    </v-dialog>
   </v-card>
 </template>
 
 <script lang="ts">
 import { uniqBy } from 'lodash'
 import Vue from 'vue'
+import { generateWifiQRCode } from 'wifi-qr-code-generator'
 
+import Notifier from '@/libs/notifier'
 import wifi from '@/store/wifi'
+import { wifi_service } from '@/types/frontend_services'
 import { Network, WifiStatus } from '@/types/wifi'
+import back_axios from '@/utils/api'
 
 import SpinningLogo from '../common/SpinningLogo.vue'
 import ConnectionDialog from './ConnectionDialog.vue'
 import DisconnectionDialog from './DisconnectionDialog.vue'
 import NetworkCard from './NetworkCard.vue'
+import WifiSettingsDialog from './WifiSettingsDialog.vue'
+
+const notifier = new Notifier(wifi_service)
 
 export default Vue.extend({
   name: 'WifiManager',
@@ -75,12 +138,17 @@ export default Vue.extend({
     SpinningLogo,
     ConnectionDialog,
     DisconnectionDialog,
+    WifiSettingsDialog,
   },
   data() {
     return {
       selected_network: null as Network | null,
       show_connection_dialog: false,
       show_disconnection_dialog: false,
+      hotspot_status_loading: false,
+      show_settings_menu: false,
+      show_qr_code_dialog: false,
+      wifi_qr_code_img: '',
     }
   },
   computed: {
@@ -93,6 +161,14 @@ export default Vue.extend({
     connectable_networks(): Network[] | null {
       return uniqBy(wifi.connectable_networks, 'ssid')
     },
+    hotspot_status(): boolean | null {
+      return wifi.hotspot_status
+    },
+  },
+  watch: {
+    hotspot_status(): void {
+      this.hotspot_status_loading = false
+    },
   },
   methods: {
     openConnectionDialog(network: Network): void {
@@ -101,6 +177,42 @@ export default Vue.extend({
     },
     openDisconnectionDialog(): void {
       this.show_disconnection_dialog = true
+    },
+    toggleSettingsMenu(): void {
+      this.show_settings_menu = true
+    },
+    async toggleQrCodeDialog(): Promise<void> {
+      await this.updateQrCode()
+      this.show_qr_code_dialog = true
+    },
+    async updateQrCode(): Promise<void> {
+      if (wifi.hotspot_credentials === null) { return }
+      const qrCodePromise = generateWifiQRCode({
+        ssid: wifi.hotspot_credentials.ssid,
+        password: wifi.hotspot_credentials.password,
+        encryption: 'WPA',
+        hiddenSSID: false,
+        outputFormat: { type: 'image/png' },
+      })
+      const data = await qrCodePromise
+      console.log(data)
+      this.wifi_qr_code_img = data
+    },
+    async toggleHotspot(): Promise<void> {
+      this.hotspot_status_loading = true
+      await back_axios({
+        method: 'post',
+        url: `${wifi.API_URL}/hotspot`,
+        params: { enable: !wifi.hotspot_status },
+        timeout: 20000,
+      })
+        .then(() => {
+          notifier.pushSuccess('HOTSPOT_STATUS_TOGGLE_SUCCESS', 'Successfully toggled hotspot state.')
+        })
+        .catch((error) => {
+          wifi.setHotspotStatus(null)
+          notifier.pushBackError('HOTSPOT_STATUS_TOGGLE_FAIL', error, true)
+        })
     },
   },
 })

--- a/core/frontend/src/components/wifi/WifiSettingsDialog.vue
+++ b/core/frontend/src/components/wifi/WifiSettingsDialog.vue
@@ -1,0 +1,148 @@
+<template>
+  <v-dialog
+    width="300"
+    :value="show"
+    @input="showDialog"
+  >
+    <v-card>
+      <v-card-title class="text-h5">
+        Wifi settings
+      </v-card-title>
+
+      <v-card-text>
+        <v-form
+          ref="form"
+          lazy-validation
+        >
+          <v-text-field
+            v-model="inputed_ssid"
+            label="Hotspot SSID"
+            hide-details="auto"
+            :rules="[isValidSSID]"
+          />
+          <v-text-field
+            v-model="inputed_password"
+            label="Hotspot password"
+            hide-details="auto"
+            :rules="[isValidPassword]"
+          />
+
+          <v-checkbox
+            v-model="enable_smart_hotspot"
+            v-tooltip="'Auto-start hotspot when not connected to a wifi network for some time.'"
+            label="Enable smart-hotspot"
+          />
+
+          <v-container class="d-flex justify-end">
+            <v-btn
+              v-if="!saving_settings"
+              color="success"
+              class="ma-1"
+              @click="saveSettings"
+            >
+              Save
+            </v-btn>
+          </v-container>
+        </v-form>
+      </v-card-text>
+      <v-card-text v-if="saving_settings">
+        Saving settings, please wait...
+        <v-progress-linear
+          indeterminate
+          color="primary"
+          class="mb-0"
+        />
+      </v-card-text>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+import Notifier from '@/libs/notifier'
+import wifi from '@/store/wifi'
+import { wifi_service } from '@/types/frontend_services'
+import { VForm } from '@/types/vuetify'
+import { NetworkCredentials } from '@/types/wifi'
+import back_axios from '@/utils/api'
+
+const notifier = new Notifier(wifi_service)
+
+export default Vue.extend({
+  name: 'WifiSettingsDialog',
+  model: {
+    prop: 'show',
+    event: 'change',
+  },
+  props: {
+    show: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      inputed_ssid: wifi.hotspot_credentials?.ssid || '',
+      inputed_password: wifi.hotspot_credentials?.password || '',
+      enable_smart_hotspot: true,
+      saving_settings: false,
+    }
+  },
+  computed: {
+    form(): VForm {
+      return this.$refs.form as VForm
+    },
+  },
+  methods: {
+    async saveSettings(): Promise<boolean> {
+      if (!this.form.validate()) {
+        return false
+      }
+      this.saving_settings = true
+      try {
+        const credentials: NetworkCredentials = { ssid: this.inputed_ssid, password: this.inputed_password }
+        await back_axios({
+          method: 'post',
+          url: `${wifi.API_URL}/hotspot_credentials`,
+          data: credentials,
+          timeout: 20000,
+        })
+          .then(() => {
+            notifier.pushSuccess('HOTSPOT_CREDENTIALS_UPDATE_SUCCESS', 'Successfully updated hotspot credentials.')
+          })
+          .catch((error) => {
+            notifier.pushBackError('HOTSPOT_CREDENTIALS_UPDATE_FAIL', error, true)
+          })
+        await back_axios({
+          method: 'post',
+          url: `${wifi.API_URL}/smart_hotspot`,
+          params: { enable: this.enable_smart_hotspot },
+          timeout: 10000,
+        })
+          .then(() => {
+            notifier.pushSuccess('SMART_HOTSPOT_TOGGLE_SUCCESS', 'Successfully updated smart-hotspot configuration.')
+          })
+          .catch((error) => {
+            notifier.pushBackError('SMART_HOTSPOT_TOGGLE_FAIL', error, true)
+          })
+        this.showDialog(false)
+        return true
+      } catch (error) {
+        return false
+      } finally {
+        this.saving_settings = false
+      }
+    },
+    isValidSSID(input: string): (true | string) {
+      return input.length >= 1 ? true : 'SSID cannot be blank.'
+    },
+    isValidPassword(input: string): (true | string) {
+      return input.length >= 8 ? true : 'Password must have at least 8 characters.'
+    },
+    showDialog(state: boolean): void {
+      this.$emit('change', state)
+    },
+  },
+})
+</script>

--- a/core/frontend/src/components/wifi/WifiUpdater.vue
+++ b/core/frontend/src/components/wifi/WifiUpdater.vue
@@ -19,7 +19,9 @@ export default Vue.extend({
   mounted() {
     callPeriodically(this.fetchSavedNetworks, 5000)
     callPeriodically(this.fetchNetworkStatus, 5000)
+    callPeriodically(this.fetchHotspotStatus, 10000)
     callPeriodically(this.fetchAvailableNetworks, 10000)
+    callPeriodically(this.fetchHotspotCredentials, 10000)
   },
   methods: {
     async fetchNetworkStatus(): Promise<void> {
@@ -53,6 +55,34 @@ export default Vue.extend({
           if (error === backend_offline_error) { return }
           const message = `Could not fetch wifi status: ${error.message}`
           notifier.pushError('WIFI_STATUS_FETCH_FAIL', message)
+        })
+    },
+    async fetchHotspotStatus(): Promise<void> {
+      await back_axios({
+        method: 'get',
+        url: `${wifi.API_URL}/hotspot`,
+        timeout: 10000,
+      })
+        .then((response) => {
+          wifi.setHotspotStatus(response.data)
+        })
+        .catch((error) => {
+          wifi.setHotspotStatus(null)
+          notifier.pushBackError('HOTSPOT_STATUS_FETCH_FAIL', error)
+        })
+    },
+    async fetchHotspotCredentials(): Promise<void> {
+      await back_axios({
+        method: 'get',
+        url: `${wifi.API_URL}/hotspot_credentials`,
+        timeout: 10000,
+      })
+        .then((response) => {
+          wifi.setHotspotCredentials(response.data)
+        })
+        .catch((error) => {
+          wifi.setHotspotCredentials(null)
+          notifier.pushBackError('HOTSPOT_CREDENTIALS_FETCH_FAIL', error)
         })
     },
     async fetchAvailableNetworks(): Promise<void> {

--- a/core/frontend/src/components/wifi/WifiUpdater.vue
+++ b/core/frontend/src/components/wifi/WifiUpdater.vue
@@ -20,7 +20,7 @@ export default Vue.extend({
     callPeriodically(this.fetchSavedNetworks, 5000)
     callPeriodically(this.fetchNetworkStatus, 5000)
     callPeriodically(this.fetchHotspotStatus, 10000)
-    callPeriodically(this.fetchAvailableNetworks, 10000)
+    callPeriodically(this.fetchAvailableNetworks, 20000)
     callPeriodically(this.fetchHotspotCredentials, 10000)
   },
   methods: {

--- a/core/frontend/src/store/wifi.ts
+++ b/core/frontend/src/store/wifi.ts
@@ -3,7 +3,9 @@ import {
 } from 'vuex-module-decorators'
 
 import store from '@/store'
-import { Network, SavedNetwork, WifiStatus } from '@/types/wifi'
+import {
+  Network, NetworkCredentials, SavedNetwork, WifiStatus,
+} from '@/types/wifi'
 import { sorted_networks } from '@/utils/wifi'
 
 @Module({
@@ -23,6 +25,10 @@ class WifiStore extends VuexModule {
 
   network_status: WifiStatus | null = null
 
+  hotspot_status: boolean | null = null
+
+  hotspot_credentials: NetworkCredentials | null = null
+
   @Mutation
   setCurrentNetwork(network: Network | null): void {
     this.current_network = network
@@ -41,6 +47,16 @@ class WifiStore extends VuexModule {
   @Mutation
   setNetworkStatus(status: WifiStatus | null): void {
     this.network_status = status
+  }
+
+  @Mutation
+  setHotspotStatus(status: boolean | null): void {
+    this.hotspot_status = status
+  }
+
+  @Mutation
+  setHotspotCredentials(credentials: NetworkCredentials | null): void {
+    this.hotspot_credentials = credentials
   }
 
   get connectable_networks(): Network[] | null {

--- a/core/frontend/yarn.lock
+++ b/core/frontend/yarn.lock
@@ -3494,6 +3494,11 @@ diffie-hellman@^5.0.0:
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
 
+dijkstrajs@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/dijkstrajs/-/dijkstrajs-1.0.2.tgz#2e48c0d3b825462afe75ab4ad5e829c8ece36257"
+  integrity sha512-QV6PMaHTCNmKSeP6QoXhVTw9snc9VD8MulTT0Bd99Pacp4SS1cjcrYPgBPmibqKVtMJJfqC6XvOXgPMEEPH/fg==
+
 dir-glob@^2.0.0, dir-glob@^2.2.2:
   version "2.2.2"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.2.2.tgz#fa09f0694153c8918b18ba0deafae94769fc50c4"
@@ -3697,6 +3702,11 @@ emojis-list@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/emojis-list/-/emojis-list-3.0.0.tgz#5570662046ad29e2e916e71aae260abdff4f6a78"
   integrity sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==
+
+encode-utf8@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/encode-utf8/-/encode-utf8-1.0.3.tgz#f30fdd31da07fb596f281beb2f6b027851994cda"
+  integrity sha512-ucAnuBEhUK4boH2HjVYG5Q2mQyPorvv0u/ocS+zhdw0S8AlHYY+GOFhP1Gio5z4icpP2ivFSvhtFjQi8+T9ppw==
 
 encodeurl@~1.0.2:
   version "1.0.2"
@@ -4454,7 +4464,7 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
-find-up@^4.0.0:
+find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
   integrity sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
@@ -7018,6 +7028,11 @@ pkg-up@^2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pngjs@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/pngjs/-/pngjs-5.0.0.tgz#e79dd2b215767fd9c04561c01236df960bce7fbb"
+  integrity sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==
+
 pnp-webpack-plugin@^1.6.4:
   version "1.6.4"
   resolved "https://registry.yarnpkg.com/pnp-webpack-plugin/-/pnp-webpack-plugin-1.6.4.tgz#c9711ac4dc48a685dabafc86f8b6dd9f8df84149"
@@ -7499,6 +7514,16 @@ q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=
+
+qrcode@^1.4.4:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/qrcode/-/qrcode-1.5.1.tgz#0103f97317409f7bc91772ef30793a54cd59f0cb"
+  integrity sha512-nS8NJ1Z3md8uTjKtP+SGGhfqmTCs5flU/xR623oI0JX+Wepz9R8UrRVCTBTJm3qGw3rH6jJ6MUHjkDx15cxSSg==
+  dependencies:
+    dijkstrajs "^1.0.1"
+    encode-utf8 "^1.0.3"
+    pngjs "^5.0.0"
+    yargs "^15.3.1"
 
 qs@6.7.0:
   version "6.7.0"
@@ -9512,6 +9537,13 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
+wifi-qr-code-generator@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/wifi-qr-code-generator/-/wifi-qr-code-generator-1.1.1.tgz#e76e5c649c8fad207e69a3b0b3dedbced4b8403c"
+  integrity sha512-AwxGwDkgQI++U/+uIdr51HBl+UN906VUGwyaKO7ROZAFGDFR/gpNNfosZya99Pftwo8YY8oSyTDAOXWIEPg+Xg==
+  dependencies:
+    qrcode "^1.4.4"
+
 word-wrap@^1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
@@ -9748,6 +9780,14 @@ yargs-parser@^13.1.2:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
 
+yargs-parser@^18.1.2:
+  version "18.1.3"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-18.1.3.tgz#be68c4975c6b2abf469236b0c870362fab09a7b0"
+  integrity sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+  dependencies:
+    camelcase "^5.0.0"
+    decamelize "^1.2.0"
+
 yargs-parser@^20.2.2:
   version "20.2.7"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.7.tgz#61df85c113edfb5a7a4e36eb8aa60ef423cbc90a"
@@ -9768,6 +9808,23 @@ yargs@^13.3.2:
     which-module "^2.0.0"
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
+
+yargs@^15.3.1:
+  version "15.4.1"
+  resolved "https://registry.yarnpkg.com/yargs/-/yargs-15.4.1.tgz#0d87a16de01aee9d8bec2bfbf74f67851730f4f8"
+  integrity sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+  dependencies:
+    cliui "^6.0.0"
+    decamelize "^1.2.0"
+    find-up "^4.1.0"
+    get-caller-file "^2.0.1"
+    require-directory "^2.1.1"
+    require-main-filename "^2.0.0"
+    set-blocking "^2.0.0"
+    string-width "^4.2.0"
+    which-module "^2.0.0"
+    y18n "^4.0.0"
+    yargs-parser "^18.1.2"
 
 yargs@^16.0.0:
   version "16.2.0"

--- a/core/libs/commonwealth/commonwealth/utils/DHCPServerManager.py
+++ b/core/libs/commonwealth/commonwealth/utils/DHCPServerManager.py
@@ -1,6 +1,7 @@
 import pathlib
 import shutil
 import subprocess
+import time
 from ipaddress import IPv4Address, IPv4Interface, IPv4Network
 from typing import Any, List, Optional, Union
 
@@ -97,6 +98,10 @@ class Dnsmasq:
         try:
             # pylint: disable=consider-using-with
             self._subprocess = subprocess.Popen(self.command_list(), shell=False, encoding="utf-8", errors="ignore")
+            time.sleep(3)
+            if not self.is_running():
+                exit_code = self._subprocess.returncode
+                raise RuntimeError(f"Failed to initialize Dnsmasq ({exit_code}).")
             logger.info("DHCP Server started.")
         except Exception as error:
             raise RuntimeError("Unable to start DHCP Server.") from error

--- a/core/libs/commonwealth/commonwealth/utils/general.py
+++ b/core/libs/commonwealth/commonwealth/utils/general.py
@@ -1,5 +1,23 @@
 import os
 
+from loguru import logger
+
 
 def is_running_as_root() -> bool:
     return os.geteuid() == 0
+
+
+def device_id() -> str:
+    try:
+        with open("/sys/firmware/devicetree/base/serial-number", "r", encoding="utf-8") as f:
+            return f.read()
+    except Exception as error:
+        logger.exception(f"Could not get device's serial-number. {error}")
+
+    try:
+        with open("/etc/machine-id", "r", encoding="utf-8") as f:
+            return "".join(f.read().split())
+    except Exception as error:
+        logger.exception(f"Could not get device's machine-id. {error}")
+
+    raise ValueError("Could not get device id.")

--- a/core/services/beacon/default-settings.json
+++ b/core/services/beacon/default-settings.json
@@ -18,6 +18,12 @@
         "domain_names": ["blueos-wifi"],
         "advertise": ["_http"],
         "ip": "ips[0]"
+      },
+      {
+        "name": "uap0",
+        "domain_names": ["blueos-wifi"],
+        "advertise": ["_http"],
+        "ip": "ips[0]"
       }
     ],
     "advertisement_types": [

--- a/core/services/wifi/Hotspot.py
+++ b/core/services/wifi/Hotspot.py
@@ -1,0 +1,371 @@
+import hashlib
+import pathlib
+import shlex
+import shutil
+import subprocess
+import tempfile
+import time
+from enum import Enum
+from ipaddress import IPv4Address
+from typing import Any, Callable, List, Optional
+
+import psutil
+from commonwealth.utils.DHCPServerManager import Dnsmasq as DHCPServerManager
+from commonwealth.utils.general import device_id
+from loguru import logger
+from pyroute2 import IW, IPRoute
+
+from typedefs import WifiCredentials
+
+
+class HostapdFrequency(str, Enum):
+    """Valid hostapd frequency modes."""
+
+    HW_2_4 = "g"  # Hostapd id for 2.4 GHz mode
+    HW_5_0 = "a"  # Hostapd id for 5.0 GHz mode
+
+    @staticmethod
+    def mode_from_channel_frequency(frequency: int) -> "HostapdFrequency":
+        return HostapdFrequency.HW_2_4 if int(frequency / 100) == 24 else HostapdFrequency.HW_5_0
+
+
+class HotspotManager:
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-arguments
+    def __init__(
+        self,
+        base_interface: str,
+        ipv4_gateway: IPv4Address,
+        ap_interface_name: str = "uap0",
+        ap_ssid: Optional[str] = None,
+        ap_passphrase: Optional[str] = None,
+    ) -> None:
+        self.iw = IW()
+        self.ipr = IPRoute()
+
+        self._ap_interface_name = ap_interface_name
+
+        try:
+            dev_id = device_id()
+        except Exception:
+            dev_id = "000000"
+        hashed_id = hashlib.md5(dev_id.encode()).hexdigest()[:6]
+        self._ap_ssid = ap_ssid or f"BlueOS ({hashed_id})"
+
+        self._ap_passphrase = ap_passphrase or "blueosap"
+
+        self._subprocess: Optional[Any] = None
+
+        if base_interface not in psutil.net_if_stats():
+            raise ValueError(f"Base interface '{base_interface}' not found.")
+        self._base_interface = base_interface
+
+        self._ipv4_gateway = ipv4_gateway
+
+        self._include_interface_on_dhcpcd()
+
+        self._dhcp_server: Optional[DHCPServerManager] = None
+
+        binary_path = shutil.which(self.binary_name())
+        if binary_path is None:
+            raise ValueError("Hostapd binary not found on system's PATH.")
+
+        self._binary = pathlib.Path(binary_path)
+        assert self.is_binary_working()
+
+    @staticmethod
+    def binary_name() -> str:
+        return "hostapd"
+
+    def binary(self) -> pathlib.Path:
+        return self._binary
+
+    def set_credentials(self, credentials: WifiCredentials) -> None:
+        logger.debug(f"Changing hotspot ssid to '{credentials.ssid}' and passphrase to '{credentials.password}'.")
+        self._ap_ssid = credentials.ssid
+        self._ap_passphrase = credentials.password
+
+    @property
+    def credentials(self) -> WifiCredentials:
+        return WifiCredentials(ssid=self._ap_ssid, password=self._ap_passphrase)
+
+    def is_binary_working(self) -> bool:
+        try:
+            subprocess.check_output([self.binary(), "-h"])
+            return True
+        except subprocess.CalledProcessError as error:
+            if error.returncode == 1:
+                return True
+            logger.error(f"Invalid binary: {error}")
+            return False
+
+    def base_interface_channel_frequency(self) -> int:
+        wireless_interfaces = self.iw.get_interfaces_dict()
+        if not self._base_interface in wireless_interfaces:
+            raise RuntimeError("Could not find base interface.")
+        last_channel = -1
+        time_last_channel_change = time.time()
+        time_start_searching = time.time()
+        while True:
+            current_channel = int(wireless_interfaces[self._base_interface][3])
+            if current_channel != last_channel:
+                time_last_channel_change = time.time()
+                last_channel = current_channel
+            seconds_in_same_channel = time.time() - time_last_channel_change
+            seconds_searching = time.time() - time_start_searching
+            if seconds_in_same_channel > 2:
+                return current_channel
+            if seconds_searching > 15:
+                raise RuntimeError("Could not find base interface channel. Timeout exceeded.")
+
+    def desired_channel_frequency(self) -> int:
+        return self.base_interface_channel_frequency()
+
+    def _create_virtual_interface(self) -> None:
+        logger.debug("Deleting virtual access point interface (if exists).")
+        wireless_interfaces = self.iw.get_interfaces_dict()
+        if self._ap_interface_name in wireless_interfaces:
+            interface_index = int(self.ipr.link_lookup(ifname=self._ap_interface_name)[0])
+            self.iw.del_interface(interface_index)
+        self._reach_condition_or_timeout(
+            lambda self: self._ap_interface_name not in self.iw.get_interfaces_dict(),
+            "Could not delete virtual interface. Timeout exceeded.",
+        )
+
+        logger.debug("Creating virtual access point interface.")
+        # pylint: disable=consider-using-with
+        subprocess.Popen(
+            shlex.split(f"iw dev {self._base_interface} interface add {self._ap_interface_name} type __ap")
+        )
+        # Following 2 lines are an alternative I could not get to work since its docs are not very clear
+        # base_interface_index = int(self.ipr.link_lookup(ifname=self._base_interface)[0])
+        # self.iw.add_interface(ifname=self._ap_interface_name, iftype="ap_vlan", dev=base_interface_index)
+        self._reach_condition_or_timeout(
+            lambda self: self._ap_interface_name in psutil.net_if_stats(),
+            "Could not create virtual interface. Timeout exceeded.",
+        )
+
+        logger.debug("Starting virtual access point interface.")
+        # pylint: disable=consider-using-with
+        subprocess.Popen(shlex.split(f"ifconfig {self._ap_interface_name} up"))
+        # Following 2 lines are an alternative I could not get to work since its docs are not very clear
+        # virtual_interface_index = int(self.ipr.link_lookup(ifname=self._ap_interface_name)[0])
+        # self.ipr.link("set", index=virtual_interface_index, state="up")
+        self._reach_condition_or_timeout(
+            lambda self: self._ap_interface_name in psutil.net_if_stats() and psutil.net_if_stats()[self._ap_interface_name][0],  # fmt: skip
+            "Could not start virtual interface. Timeout exceeded.",
+        )
+
+    def command_list(self) -> List[str]:
+        return shlex.split(f"{self.binary()} {self.config_path()}")
+
+    def start(self) -> None:
+        logger.info("Starting hotspot.")
+        try:
+            self._create_temp_config_file()
+            self._create_virtual_interface()
+            # pylint: disable=consider-using-with
+            if not self.is_running():
+                self._subprocess = subprocess.Popen(self.command_list(), shell=False, encoding="utf-8", errors="ignore")
+                time.sleep(3)
+                if not self.is_running():
+                    exit_code = self._subprocess.returncode
+                    raise RuntimeError(f"Failed to initialize Hostapd ({exit_code}).")
+            if not self._dhcp_server:
+                self._dhcp_server = DHCPServerManager(self._ap_interface_name, self._ipv4_gateway)
+                return
+            self._dhcp_server.restart()
+        except Exception as error:
+            raise RuntimeError(f"Unable to start hotspot. {error}") from error
+
+    def stop(self) -> None:
+        logger.info("Stopping hotspot.")
+        if self.is_running():
+            assert self._subprocess is not None
+            self._subprocess.kill()
+            if not self._dhcp_server:
+                logger.warning("Cannot stop DHCP server for hotspot, as was already not running.")
+                return
+            self._dhcp_server.stop()
+        else:
+            logger.info("Tried to stop hostpot, but it was already not running.")
+
+    def restart(self) -> None:
+        self.stop()
+        self.start()
+
+    def is_running(self) -> bool:
+        return self._subprocess is not None and self._subprocess.poll() is None
+
+    @staticmethod
+    def config_path() -> pathlib.Path:
+        config_dir = pathlib.Path(tempfile.tempdir or "/")
+        return config_dir.joinpath("hostapd.conf")
+
+    def hostapd_config(self) -> str:
+        desired_channel_frequency = self.desired_channel_frequency()
+        desired_channel_number = HotspotManager.channel_number(desired_channel_frequency)
+
+        return (
+            "# WiFi interface to be used (in this case a virtual one)\n"
+            f"interface={self._ap_interface_name}\n"
+            "# Channel (frequency) of the access point\n"
+            f"channel={desired_channel_number}\n"
+            "# SSID broadcasted by the access point\n"
+            f'ssid2="{self._ap_ssid}"\n'
+            "# Passphrase for the access point\n"
+            f"wpa_passphrase={self._ap_passphrase}\n"
+            "# Use the 2.4GHz band\n"
+            f"hw_mode={HostapdFrequency.mode_from_channel_frequency(desired_channel_frequency).value}\n"
+            "# Accept all MAC addresses\n"
+            "macaddr_acl=0\n"
+            "# Use WPA authentication\n"
+            "auth_algs=1\n"
+            "# Require clients to know the network name\n"
+            "ignore_broadcast_ssid=0\n"
+            "# Use WPA2\n"
+            "wpa=2\n"
+            "# Use a pre-shared key\n"
+            "wpa_key_mgmt=WPA-PSK\n"
+            "wpa_pairwise=TKIP\n"
+            "rsn_pairwise=CCMP\n"
+        )
+
+    def _create_temp_config_file(self) -> None:
+        logger.info(f"Saving temporary hostapd config file on {self.config_path()}")
+        with open(self.config_path(), "w", encoding="utf-8") as f:
+            f.write(self.hostapd_config())
+
+    def _include_interface_on_dhcpcd(self) -> None:
+        with open("/etc/dhcpcd.conf", "r", encoding="utf-8") as f:
+            original_lines = f.readlines()
+
+            start_line = -1
+            end_line = -1
+            for i, line in enumerate(original_lines):
+                if "blueos-start" in line:
+                    start_line = i
+                if "blueos-end" in line:
+                    end_line = i
+            lines_to_remove: List[int] = []
+            if start_line != -1 and end_line != -1:
+                lines_to_remove = list(range(start_line, end_line + 1))
+
+            new_lines = []
+            for i, line in enumerate(original_lines):
+                if i not in lines_to_remove:
+                    new_lines.append(line)
+
+            if not str(new_lines[-1]).endswith("\n"):
+                new_lines.append("\n")
+
+            if str(new_lines[-1]) != "\n":
+                new_lines.append("\n")
+            new_lines.append("#blueos-start\n")
+            new_lines.append(f"interface {self._ap_interface_name}\n")
+            new_lines.append(f"    static ip_address={self._ipv4_gateway}/24\n")
+            new_lines.append("    nohook wpa_supplicant\n")
+            new_lines.append("END\n")
+            new_lines.append("#blueos-end\n")
+
+        with open("/etc/dhcpcd.conf", "w", encoding="utf-8") as f:
+            f.writelines(new_lines)
+
+    def _reach_condition_or_timeout(self, condition: Callable[["HotspotManager"], bool], timeout_message: str) -> None:
+        time_start = time.time()
+        while True:
+            if condition(self):
+                time.sleep(0.3)
+                break
+            if time.time() - time_start > 5:
+                raise RuntimeError(timeout_message)
+            time.sleep(0.1)
+
+    @staticmethod
+    def channel_number(frequency: int) -> int:
+        return {
+            2412: 1,
+            2417: 2,
+            2422: 3,
+            2427: 4,
+            2432: 5,
+            2437: 6,
+            2442: 7,
+            2447: 8,
+            2452: 9,
+            2457: 10,
+            2462: 11,
+            2467: 12,
+            2472: 13,
+            2484: 14,
+            5035: 7,
+            5040: 8,
+            5045: 9,
+            5055: 11,
+            5060: 12,
+            5080: 16,
+            5160: 32,
+            5170: 34,
+            5180: 36,
+            5190: 38,
+            5200: 40,
+            5210: 42,
+            5220: 44,
+            5230: 46,
+            5240: 48,
+            5250: 50,
+            5260: 52,
+            5270: 54,
+            5280: 56,
+            5290: 58,
+            5300: 60,
+            5310: 62,
+            5320: 64,
+            5340: 68,
+            5480: 96,
+            5500: 100,
+            5510: 102,
+            5520: 104,
+            5530: 106,
+            5540: 108,
+            5550: 110,
+            5560: 112,
+            5570: 114,
+            5580: 116,
+            5590: 118,
+            5600: 120,
+            5610: 122,
+            5620: 124,
+            5630: 126,
+            5640: 128,
+            5660: 132,
+            5670: 134,
+            5680: 136,
+            5690: 138,
+            5700: 140,
+            5710: 142,
+            5720: 144,
+            5745: 149,
+            5755: 151,
+            5765: 153,
+            5775: 155,
+            5785: 157,
+            5795: 159,
+            5805: 161,
+            5815: 163,
+            5825: 165,
+            5835: 167,
+            5845: 169,
+            5855: 171,
+            5865: 173,
+            5875: 175,
+            5885: 177,
+            5910: 182,
+            5915: 183,
+            5920: 184,
+            5935: 187,
+            5940: 188,
+            5945: 189,
+            5960: 192,
+            5980: 196,
+        }[frequency]

--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -114,7 +114,7 @@ class WifiManager:
                 # where this one is running can check when it has finished.
                 # Otherwise, it could happen that a new scan is initiated before the ones waiting know
                 # the previous one has finished, making them stay on the loop unnecessarily.
-                self._scan_task = asyncio.create_task(self.wpa.send_command_scan(timeout=15))
+                self._scan_task = asyncio.create_task(self.wpa.send_command_scan(timeout=30))
                 await self._scan_task
                 data = await self.wpa.send_command_scan_results()
                 networks_list = WifiManager.__dict_from_table(data)
@@ -186,7 +186,7 @@ class WifiManager:
         except Exception as error:
             raise ConnectionError("Failed to remove existing network.") from error
 
-    async def connect_to_network(self, network_id: int, timeout: float = 10.0) -> None:
+    async def connect_to_network(self, network_id: int, timeout: float = 20.0) -> None:
         """Connect to wifi network
 
         Arguments:

--- a/core/services/wifi/main.py
+++ b/core/services/wifi/main.py
@@ -143,6 +143,42 @@ async def disconnect() -> Any:
     logger.info("Succesfully disconnected from network.")
 
 
+@app.get("/hotspot", summary="Get hotspot state.")
+@version(1, 0)
+def hotspot_state() -> Any:
+    return wifi_manager._hotspot.is_running()
+
+
+@app.post("/hotspot", summary="Enable/disable hotspot.")
+@version(1, 0)
+def toggle_hotspot(enable: bool) -> Any:
+    if enable:
+        wifi_manager.enable_hotspot()
+        return
+    wifi_manager.disable_hotspot()
+
+
+@app.post("/smart_hotspot", summary="Enable/disable smart-hotspot.")
+@version(1, 0)
+def toggle_smart_hotspot(enable: bool) -> Any:
+    if enable:
+        wifi_manager.enable_smart_hotspot()
+        return
+    wifi_manager.disable_smart_hotspot()
+
+
+@app.post("/hotspot_credentials", summary="Update hotspot credentials.")
+@version(1, 0)
+def set_hotspot_credentials(credentials: WifiCredentials) -> Any:
+    wifi_manager.set_hotspot_credentials(credentials)
+
+
+@app.get("/hotspot_credentials", summary="Get hotspot credentials.")
+@version(1, 0)
+def get_hotspot_credentials() -> Any:
+    return wifi_manager.hotspot_credentials()
+
+
 app = VersionedFastAPI(app, version="1.0.0", prefix_format="/v{major}.{minor}", enable_latest=True)
 app.mount("/", StaticFiles(directory=str(FRONTEND_FOLDER), html=True))
 

--- a/core/services/wifi/main.py
+++ b/core/services/wifi/main.py
@@ -226,5 +226,5 @@ if __name__ == "__main__":
     config = Config(app=app, loop=loop, host="0.0.0.0", port=9000, log_config=None)
     server = Server(config)
 
-    loop.create_task(wifi_manager.auto_reconnect(10.0))
+    loop.create_task(wifi_manager.auto_reconnect(60))
     loop.run_until_complete(server.serve())

--- a/core/services/wifi/settings.py
+++ b/core/services/wifi/settings.py
@@ -1,0 +1,26 @@
+from typing import Any, Dict
+
+import pykson  # type: ignore
+from commonwealth.settings import settings
+
+
+class SettingsV1(settings.BaseSettings):
+    VERSION = 1
+    hotspot_enabled = pykson.BooleanField()
+    hotspot_ssid = pykson.StringField()
+    hotspot_password = pykson.StringField()
+    smart_hotspot_enabled = pykson.BooleanField()
+
+    def __init__(self, *args: str, **kwargs: int) -> None:
+        super().__init__(*args, **kwargs)
+
+        self.VERSION = SettingsV1.VERSION
+
+    def migrate(self, data: Dict[str, Any]) -> None:
+        if data["VERSION"] == SettingsV1.VERSION:
+            return
+
+        if data["VERSION"] < SettingsV1.VERSION:
+            super().migrate(data)
+
+        data["VERSION"] = SettingsV1.VERSION

--- a/core/tools/blueos_startup_update/blueos_startup_update
+++ b/core/tools/blueos_startup_update/blueos_startup_update
@@ -13,6 +13,14 @@ DELTA_JSON = {
             '/run/udev': {
                 'bind': '/run/udev',
                 'mode': 'ro'
+            },
+            '/etc/machine-id': {
+                'bind': '/etc/machine-id',
+                'mode': 'ro'
+            },
+            '/etc/dhcpcd.conf': {
+                'bind': '/etc/dhcpcd.conf',
+                'mode': 'rw'
             }
         }
     }

--- a/core/tools/hotspot/bootstrap.sh
+++ b/core/tools/hotspot/bootstrap.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+# Exit if something goes wrong
+set -e
+
+# Hostapd turns a network wireless interface into a wifi hotspot
+echo "Installing hostapd."
+apt install -y --no-install-recommends hostapd
+
+# Iw and net-tools are used by the hotspot manager to configure the network interfaces
+echo "Installing iw and net-tools."
+apt install -y --no-install-recommends iw
+apt install -y --no-install-recommends net-tools

--- a/core/tools/install-system-tools.sh
+++ b/core/tools/install-system-tools.sh
@@ -7,6 +7,7 @@ set -e
 TOOLS=(
     ardupilot_tools
     filebrowser
+    hotspot
     linux2rest
     logviewer
     mavlink_camera_manager


### PR DESCRIPTION
~This branch had it development stalled for some months to focus on other priorities. I'm pushing it as it was.
Last time I've checked, it was already working, but had several code improvements to be made. Once the CI builds the image, I'm going to test it to confirm.
I will put some work to finish it in the next weeks.~

<img width="585" alt="image" src="https://user-images.githubusercontent.com/6551040/180869250-5832f567-0ec2-4024-8a0c-a7769597fa77.png">


Hotspot is now working, in parallel with wifi-client-behavior.

The main use-case for this feature is for the user to be able to connect to the Raspberry board if cabled-ethernet is not working or no known network is nearby, and from the frontend to debug its board and/or connect to a known wifi network.

By default, the hotspot is enabled, and it also auto-starts itself whenever there's no connection to any known wifi network for more than the watchdog timeout. We call the latter smart-hotspot.

If a user is on the hotspot, access the frontend and from there successfully connect to a known network, the hotspot will be disabled.

Default credentials are:
- SSID: BlueOS (FIRST_SIX_SERIAL_CHARS)
- Password: blueosap

The credentials can be changed by the user from the frontend interface.
The hotspot can also be enabled/disabled from the frontend.
The user can also scan a dynamically generated QR code to connect to the hotspot.

Testing this was somewhat painful, as most network-related features, but in the end I think it works as expected for the main use-case. I invite anyone reviewing this to also test it. Further tests to use the hotspot as a regular long-run connection were not performed, as this is not our goal right now, but can be something to be done in the future.

~PS1: For now, users that want this feature will need to perform a full image refresh or to manually edit the DHCP client file as explained [here](https://github.com/bluerobotics/BlueOS-docker/pull/1019#issuecomment-1136351839). @patrickelectric also mentioned he wants to do something on that to allow for ease upgrade.~

~PS2: @Williangalvani I didn't add the `uap0` interface to the `blueos-wifi` beacon settings as I didn't know if Beacon would behave correctly in the case where the interface does not exist (when the hotspot is disabled). Let me know if it is ok to add it there.~

~PS3: There's no persistence for the hotspot credentials yet, so if someone changes the SSID and password, they will be reset on the next power cycle. I'm opening the PR for review but planning to add persistence before merging it.~

Fix #307 