### PR TITLE
tools: ardupilot: bootstrap: update uploader hash

### DIFF
--- a/core/tools/ardupilot_tools/bootstrap.sh
+++ b/core/tools/ardupilot_tools/bootstrap.sh
@@ -6,7 +6,7 @@ set -e
 ## Download and install necessary tools to user binary folder with the correct permissions
 
 ### Ardupilot's uploader is used to upload firmwares to serial boards
-COMMIT_HASH=4ea8c32c61781fa36dff9748fe3a18cdb5743abb
+COMMIT_HASH=f6544ca25ab232407ec102b7a5adf0adca0f2062
 LOCAL_PATH_UPLOADER="/usr/bin/ardupilot_fw_uploader.py"
 REMOTE_URL_UPLOADER="https://raw.githubusercontent.com/ArduPilot/ardupilot/${COMMIT_HASH}/Tools/scripts/uploader.py"
 


### PR DESCRIPTION
- [new `uploader.py` version](https://github.com/ArduPilot/ardupilot/commit/f6544ca25ab232407ec102b7a5adf0adca0f2062), which actually has a non-zero exit status when it fails
- relevant to https://github.com/bluerobotics/BlueOS-docker/issues/840#issuecomment-1136210399