### PR TITLE
Improve firmware management

### DIFF
--- a/core/frontend/src/components/autopilot/AutopilotManagerUpdater.vue
+++ b/core/frontend/src/components/autopilot/AutopilotManagerUpdater.vue
@@ -8,6 +8,7 @@ import Vue from 'vue'
 
 import Notifier from '@/libs/notifier'
 import autopilot from '@/store/autopilot_manager'
+import { FlightController } from '@/types/autopilot'
 import { autopilot_service } from '@/types/frontend_services'
 import back_axios from '@/utils/api'
 import { callPeriodically } from '@/utils/helper_functions'
@@ -47,19 +48,17 @@ export default Vue.extend({
         })
     },
     async fetchAvailableBoards(): Promise<void> {
-      await back_axios({
-        method: 'get',
-        url: `${autopilot.API_URL}/available_boards`,
-        timeout: 10000,
-      })
-        .then((response) => {
-          const available_boards = response.data
-          autopilot.setAvailableBoards(available_boards)
+      try {
+        const response: AxiosResponse = await back_axios({
+          method: 'get',
+          url: `${autopilot.API_URL}/available_boards`,
+          timeout: 10000,
         })
-        .catch((error) => {
-          autopilot.setAvailableBoards([])
-          notifier.pushBackError('AUTOPILOT_BOARDS_FETCH_FAIL', error)
-        })
+        autopilot.setAvailableBoards(response.data)
+      } catch (error) {
+        autopilot.setAvailableBoards([])
+        notifier.pushBackError('AUTOPILOT_BOARDS_FETCH_FAIL', error)
+      }
     },
     async fetchCurrentBoard(): Promise<void> {
       await back_axios({

--- a/core/frontend/src/components/autopilot/BoardChangeDialog.vue
+++ b/core/frontend/src/components/autopilot/BoardChangeDialog.vue
@@ -39,7 +39,7 @@ import Vue from 'vue'
 
 import Notifier from '@/libs/notifier'
 import autopilot from '@/store/autopilot_manager'
-import { FlightController } from '@/types/autopilot'
+import { FlightController, FlightControllerFlags } from '@/types/autopilot'
 import { autopilot_service } from '@/types/frontend_services'
 import { VForm } from '@/types/vuetify'
 import back_axios from '@/utils/api'
@@ -71,7 +71,9 @@ export default Vue.extend({
       )
     },
     available_boards(): FlightController[] {
-      return autopilot.available_boards
+      return autopilot.available_boards.filter(
+        (board: FlightController) => !board.flags.includes(FlightControllerFlags.is_bootloader),
+      )
     },
     form(): VForm {
       return this.$refs.form as VForm

--- a/core/frontend/src/components/autopilot/BoardChangeDialog.vue
+++ b/core/frontend/src/components/autopilot/BoardChangeDialog.vue
@@ -67,7 +67,10 @@ export default Vue.extend({
   computed: {
     board_options(): {value: FlightController, text: string}[] {
       return this.available_boards.map(
-        (board) => ({ value: board, text: board.name }),
+        (board) => ({
+          value: board,
+          text: board.name === autopilot.current_board?.name ? `${board.name} (current)` : board.name,
+        }),
       )
     },
     available_boards(): FlightController[] {

--- a/core/frontend/src/store/autopilot_manager.ts
+++ b/core/frontend/src/store/autopilot_manager.ts
@@ -62,8 +62,8 @@ class AutopilotManagerStore extends VuexModule {
   }
 
   @Mutation
-  setAvailableBoards(available_boards: FlightController[]): void {
-    this.available_boards = available_boards
+  setAvailableBoards(boards: FlightController[]): void {
+    this.available_boards = boards
     this.updating_boards = false
   }
 }

--- a/core/frontend/src/types/autopilot.ts
+++ b/core/frontend/src/types/autopilot.ts
@@ -50,11 +50,16 @@ export interface AutopilotEndpoint {
     enabled: boolean
 }
 
+export enum FlightControllerFlags {
+  is_bootloader = 'is_bootloader',
+}
+
 export interface FlightController {
   name: string
   manufacturer: string
   platform: Platform
   path: string
+  flags: FlightControllerFlags[]
 }
 
 export enum FirmwareType {

--- a/core/services/ardupilot_manager/flight_controller_detector/Detector.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/Detector.py
@@ -1,6 +1,6 @@
-import os
 from typing import List, Optional
 
+from commonwealth.utils.general import is_running_as_root
 from loguru import logger
 from serial.tools.list_ports_linux import SysFS, comports
 from smbus2 import SMBus
@@ -9,15 +9,6 @@ from typedefs import FlightController, Platform
 
 
 class Detector:
-    @staticmethod
-    def _is_root() -> bool:
-        """Check if the script is running as root
-
-        Returns:
-            bool: True if running as root
-        """
-        return os.geteuid() == 0
-
     @staticmethod
     def detect_navigator() -> Optional[FlightController]:
         """Returns Navigator board if connected.
@@ -99,7 +90,7 @@ class Detector:
             List[FlightController]: List of available flight controllers
         """
         available: List[FlightController] = []
-        if not cls._is_root():
+        if not is_running_as_root():
             return available
 
         navigator = cls.detect_navigator()

--- a/core/services/ardupilot_manager/flight_controller_detector/Detector.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/Detector.py
@@ -5,7 +5,8 @@ from loguru import logger
 from serial.tools.list_ports_linux import SysFS, comports
 from smbus2 import SMBus
 
-from typedefs import FlightController, Platform
+from flight_controller_detector.board_identification import identifiers
+from typedefs import FlightController, FlightControllerFlags, Platform
 
 
 class Detector:
@@ -45,13 +46,16 @@ class Detector:
         return None
 
     @staticmethod
+    def is_serial_bootloader(port: SysFS) -> bool:
+        return port.product is not None and "BL" in port.product
+
+    @staticmethod
     def detect_serial_platform(port: SysFS) -> Optional[Platform]:
-        if port.product in ["Pixhawk1", "PX4 FMU v2.x"]:
-            return Platform.Pixhawk1
-        if port.product in ["Pixhawk4", "PX4 FMU v5.x"]:
-            return Platform.Pixhawk4
-        if port.manufacturer in ["ArduPilot", "3D Robotics"] and (port.product and not "BL" in port.product):
-            return Platform.GenericSerial
+        for identifier in identifiers:
+            port_attr = getattr(port, identifier.attribute)
+            if port_attr is not None and identifier.id_value in port_attr:
+                return identifier.platform
+
         return None
 
     @staticmethod
@@ -67,7 +71,7 @@ class Detector:
             # usb_device_path property will be the same for two serial connections using the same USB port
             if port.usb_device_path not in [device.usb_device_path for device in unique_serial_devices]:
                 unique_serial_devices.append(port)
-        return [
+        boards = [
             FlightController(
                 name=port.product or port.name,
                 manufacturer=port.manufacturer,
@@ -77,6 +81,11 @@ class Detector:
             for port in unique_serial_devices
             if Detector.detect_serial_platform(port) is not None
         ]
+        for port in unique_serial_devices:
+            for board in boards:
+                if board.path == port.device and Detector.is_serial_bootloader(port):
+                    board.flags.append(FlightControllerFlags.is_bootloader)
+        return boards
 
     @staticmethod
     def detect_sitl() -> FlightController:
@@ -85,6 +94,9 @@ class Detector:
     @classmethod
     def detect(cls, include_sitl: bool = True) -> List[FlightController]:
         """Return a list of available flight controllers
+
+        Arguments:
+            include_sitl {bool} -- To include or not SITL controllers in the returned list
 
         Returns:
             List[FlightController]: List of available flight controllers

--- a/core/services/ardupilot_manager/flight_controller_detector/board_identification.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/board_identification.py
@@ -1,0 +1,27 @@
+from enum import Enum
+from typing import List
+
+from pydantic import BaseModel
+
+from typedefs import Platform
+
+
+class SerialAttr(str, Enum):
+    product = "product"
+    manufacturer = "manufacturer"
+
+
+class SerialBoardIdentifier(BaseModel):
+    attribute: SerialAttr
+    id_value: str
+    platform: Platform
+
+
+identifiers: List[SerialBoardIdentifier] = [
+    SerialBoardIdentifier(attribute=SerialAttr.product, id_value="Pixhawk1", platform=Platform.Pixhawk1),
+    SerialBoardIdentifier(attribute=SerialAttr.product, id_value="FMU v2.x", platform=Platform.Pixhawk1),
+    SerialBoardIdentifier(attribute=SerialAttr.product, id_value="Pixhawk4", platform=Platform.Pixhawk4),
+    SerialBoardIdentifier(attribute=SerialAttr.product, id_value="FMU v5.x", platform=Platform.Pixhawk4),
+    SerialBoardIdentifier(attribute=SerialAttr.manufacturer, id_value="ArduPilot", platform=Platform.GenericSerial),
+    SerialBoardIdentifier(attribute=SerialAttr.manufacturer, id_value="3D Robotics", platform=Platform.GenericSerial),
+]

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -187,7 +187,7 @@ async def restore_default_firmware() -> Any:
 @app.get("/available_boards", response_model=List[FlightController], summary="Retrieve list of connected boards.")
 @version(1, 0)
 def available_boards() -> Any:
-    return BoardDetector.detect()
+    return autopilot.available_boards(True)
 
 
 app = VersionedFastAPI(app, version="1.0.0", prefix_format="/v{major}.{minor}", enable_latest=True)

--- a/core/services/ardupilot_manager/typedefs.py
+++ b/core/services/ardupilot_manager/typedefs.py
@@ -118,6 +118,12 @@ class Platform(str, Enum):
         return platform_types.get(self, PlatformType.Unknown)
 
 
+class FlightControllerFlags(str, Enum):
+    """Flags for the Flight-controller class."""
+
+    is_bootloader = "is_bootloader"
+
+
 class FlightController(BaseModel):
     """Flight-controller board."""
 
@@ -125,6 +131,7 @@ class FlightController(BaseModel):
     manufacturer: Optional[str]
     platform: Platform
     path: Optional[str]
+    flags: List[FlightControllerFlags] = []
 
     @property
     def type(self) -> PlatformType:

--- a/core/services/ardupilot_manager/typedefs.py
+++ b/core/services/ardupilot_manager/typedefs.py
@@ -1,6 +1,6 @@
 from enum import Enum, auto
 from platform import machine
-from typing import Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, HttpUrl
 
@@ -136,6 +136,11 @@ class FlightController(BaseModel):
     @property
     def type(self) -> PlatformType:
         return self.platform.type
+
+
+class AvailableBoards(BaseModel):
+    regular: List[FlightController]
+    bootloaders: List[FlightController]
 
 
 class FirmwareFormat(str, Enum):


### PR DESCRIPTION
This update has two main points:
- Allowing users in Pirate Mode to flash any connected board (and not just the running board)
- Allowing users in Pirate Mode to flash serial boards that are stuck in bootloader mode

The former is the one we were aiming, letting users that had problems updating their boards and are stuck in bootloader mode to get them back running.

This helps with #865 and #840 

@ES-Alexander please let me know if this fulfills what we were aiming (lettings users get their boards back running without using terminal or other tools).

PS: I left this as a draft as I'm rethinking a better way to handle the differentiation between real boards and bootloaders, both on backend and frontend.