### PR TITLE
Fix pylint warn

### DIFF
--- a/core/services/ardupilot_manager/mavlink_proxy/test_all.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/test_all.py
@@ -53,7 +53,7 @@ def test_endpoint() -> None:
     assert endpoint.connection_type == EndpointType.UDPClient, "Connection type does not match."
     assert endpoint.place == "0.0.0.0", "Connection place does not match."
     assert endpoint.argument == 14550, "Connection argument does not match."
-    assert endpoint.__str__() == "udpout:0.0.0.0:14550", "Connection string does not match."
+    assert str(endpoint) == "udpout:0.0.0.0:14550", "Connection string does not match."
     assert endpoint.as_dict() == {
         "name": "Test endpoint",
         "owner": "pytest",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ plugins = "pydantic.mypy"
     enable = "all"
     disable = [
         "attribute-defined-outside-init",
-        "bad-continuation", # Black takes care of that for us
         "broad-except",
         "duplicate-code",
         "import-error",


### PR DESCRIPTION
[I'm confirming it](https://github.com/PyCQA/pylint/issues/6809), but apparently pylint's `bad-continuation` checker was removed.