### PR TITLE
Update mavlink camera manager 3.4.0

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -32,11 +32,10 @@ COPY services /home/pi/services
 RUN /home/pi/services/install-services.sh
 COPY start-blueos-core /usr/bin/start-blueos-core
 
-# Copy binaries from downloadBinaries to this stage
+# Copy binaries and necessary folders from downloadBinaries to this stage
 COPY --from=downloadBinaries \
     /usr/bin/bridges \
     /usr/bin/mavlink2rest \
-    /usr/bin/mavlink-camera-manager \
     /usr/bin/mavlink-routerd \
     /usr/bin/ttyd \
     /usr/bin/

--- a/core/frontend/src/components/video-manager/VideoManager.vue
+++ b/core/frontend/src/components/video-manager/VideoManager.vue
@@ -59,8 +59,11 @@ export default Vue.extend({
       return !this.video_devices.isEmpty()
     },
     video_devices(): Device[] {
-      // Check if a device provides H264
-      function has_h264(device: Device): boolean {
+      function has_supported_encode(device: Device): boolean {
+        if (settings.is_pirate_mode) {
+          return true
+        }
+
         return !device.formats.filter((format: Format) => format.encode === VideoEncodeType.H264).isEmpty()
       }
 
@@ -69,7 +72,7 @@ export default Vue.extend({
       }
 
       return video.available_devices
-        .filter(has_h264)
+        .filter(has_supported_encode)
         .filter(should_show)
         .sort((a: Device, b: Device) => a.name.localeCompare(b.name))
     },

--- a/core/frontend/src/components/video-manager/VideoStream.vue
+++ b/core/frontend/src/components/video-manager/VideoStream.vue
@@ -80,7 +80,7 @@ import Vue, { PropType } from 'vue'
 
 import video from '@/store/video'
 import {
-  CreatedStream, Device, StreamPrototype, StreamStatus,
+  CreatedStream, Device, StreamPrototype, StreamStatus, VideoCaptureType,
 } from '@/types/video'
 import { video_dimension_framerate_text } from '@/utils/video'
 

--- a/core/frontend/src/components/video-manager/VideoStreamCreationDialog.vue
+++ b/core/frontend/src/components/video-manager/VideoStreamCreationDialog.vue
@@ -119,7 +119,8 @@ import Vue, { PropType } from 'vue'
 
 import settings from '@/libs/settings'
 import {
-  CreatedStream, Device, Format, FrameInterval, Size, StreamPrototype, VideoEncodeType,
+  CreatedStream, Device, Format, FrameInterval, Size, StreamPrototype, VideoCaptureType,
+  VideoEncodeType,
 } from '@/types/video'
 import { VForm } from '@/types/vuetify'
 import { isNotEmpty, isRtspAddress, isUdpAddress } from '@/utils/pattern_validators'
@@ -193,6 +194,7 @@ export default Vue.extend({
         stream_information: {
           endpoints: this.stream_endpoints,
           configuration: {
+            type: VideoCaptureType.Video,
             encode: this.selected_encode,
             height: this.selected_size.height,
             width: this.selected_size.width,

--- a/core/frontend/src/types/video.ts
+++ b/core/frontend/src/types/video.ts
@@ -89,7 +89,13 @@ export interface Device {
   controls: Control[]
 }
 
+export enum VideoCaptureType {
+  Video = 'video',
+  Redirect = 'redirect',
+}
+
 export interface CaptureConfiguration {
+  type: VideoCaptureType
   encode: VideoEncodeType
   height: number
   width: number

--- a/core/tools/install-static-binaries.sh
+++ b/core/tools/install-static-binaries.sh
@@ -5,7 +5,6 @@ TOOLS=(
     bridges
     linux2rest
     mavlink2rest
-    mavlink_camera_manager
     mavlink_router
     ttyd
 )

--- a/core/tools/install-system-tools.sh
+++ b/core/tools/install-system-tools.sh
@@ -6,6 +6,7 @@ TOOLS=(
     filebrowser
     linux2rest
     logviewer
+    mavlink_camera_manager
     scripts
 )
 

--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -4,15 +4,22 @@
 set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink-camera-manager"
-
-VERSION=t3.3.2
+ARTIFACT_PREFIX="mavlink-camera-manager"
+VERSION=t3.4.0
 
 # By default we install armv7
-REMOTE_BINARY_URL="https://github.com/bluerobotics/mavlink-camera-manager/releases/download/${VERSION}/mavlink-camera-manager-armv7"
+REMOTE_BINARY_URL="https://github.com/bluerobotics/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-armv7.zip"
 if [[ "$(uname -m)" == "x86_64"* ]]; then
-    REMOTE_BINARY_URL="https://github.com/bluerobotics/mavlink-camera-manager/releases/download/${VERSION}/mavlink-camera-manager-linux-desktop"
+    REMOTE_BINARY_URL="https://github.com/bluerobotics/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-linux-desktop.zip"
 fi
 
 # Download and install the camera manager under user binary folder with the correct permissions
-wget "$REMOTE_BINARY_URL" -O "$LOCAL_BINARY_PATH"
+ARTIFACT_PREFIX="mavlink-camera-manager"
+wget "$REMOTE_BINARY_URL" -O "${ARTIFACT_PREFIX}.zip"
+unzip "${ARTIFACT_PREFIX}.zip" -d "${ARTIFACT_PREFIX}"
+# Binary
+cp "${ARTIFACT_PREFIX}/${ARTIFACT_PREFIX}"* "$LOCAL_BINARY_PATH"
 chmod +x "$LOCAL_BINARY_PATH"
+# WWW folder
+mkdir -p /opt/blueos/mavlink-camera-manager
+cp -r "${ARTIFACT_PREFIX}/www" /opt/blueos/mavlink-camera-manager


### PR DESCRIPTION
- [changelog](https://github.com/bluerobotics/mavlink-camera-manager/releases/tag/t3.4.0)
    - Does not enable the webrtc feature
    - Allow use of others encoders such as YUYV and MJPEG in pirate mode

docker: patrickelectric/update_mavlink_camera_manager_3_4_0