### PR TITLE
core: tools: scripts: bootstrap: Use absolute path for red-pill location.

### DIFF
--- a/core/tools/scripts/bootstrap.sh
+++ b/core/tools/scripts/bootstrap.sh
@@ -3,5 +3,5 @@
 # Exit immediately if a command exits with a non-zero status
 set -e
 
-SCRIPTS_PATH=$(dirname "$0")
-cp $PWD/$SCRIPTS_PATH/red-pill /usr/bin/
+SCRIPTS_PATH="$( cd -- "$( dirname -- "${BASH_SOURCE[0]:-$0}"; )" &> /dev/null && pwd 2> /dev/null; )";
+cp $SCRIPTS_PATH/red-pill /usr/bin/


### PR DESCRIPTION
Using relative path actually is relying on having "/" as the current working directory, which ~will~ might not be the case in future blueos-base docker images (eg. we may choose to use /home/pi as the default login path).