### PR TITLE
Use immutable with yarn

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Yarn install
         uses: borales/actions-yarn@v3.0.0
         with:
-          cmd: --cwd ./core/frontend install
+          cmd: --cwd ./core/frontend install --immutable
 
       - name: Yarn lint
         uses: borales/actions-yarn@v3.0.0

--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -8,7 +8,7 @@ RUN [ -z "$VUE_APP_GIT_DESCRIBE" ] \
     && exit 1 || exit 0
 
 COPY frontend /home/pi/frontend
-RUN --mount=type=cache,target=/home/pi/frontend/node_modules yarn --cwd /home/pi/frontend install --network-timeout=300000
+RUN --mount=type=cache,target=/home/pi/frontend/node_modules yarn --cwd /home/pi/frontend install --network-timeout=300000 --immutable
 RUN --mount=type=cache,target=/home/pi/frontend/node_modules yarn --cwd /home/pi/frontend build --skip-plugins @vue/cli-plugin-eslint
 
 # Download binaries


### PR DESCRIPTION
From yarn documentation:
> If you need reproducible dependencies, which is usually the case with the continuous integration systems, you should pass --frozen-lockfile flag.
> If you want to ensure yarn.lock is not updated, use --frozen-lockfile.

`--immutable` is the "new" waay to call `frozen-lockfile`, that's considered deprecated. 