### PR TITLE
core: frontend: NetworkTestView: explicitly local

### DIFF
--- a/core/frontend/src/views/NetworkTestView.vue
+++ b/core/frontend/src/views/NetworkTestView.vue
@@ -4,7 +4,7 @@
   >
     <v-card>
       <v-card-title class="justify-center">
-        Network speed and latency test
+        Local Network speed and latency tests
       </v-card-title>
 
       <v-divider />


### PR DESCRIPTION
Make it clear that local tests are local (and unrelated to BlueOS's connection to the internet).