### PR TITLE
wifi-manager: Perform initial scan by default

### DIFF
--- a/core/services/wifi/WifiManager.py
+++ b/core/services/wifi/WifiManager.py
@@ -34,6 +34,9 @@ class WifiManager:
         self.connection_status = ConnectionStatus.UNKNOWN
         self._time_last_scan = 0.0
 
+        # Perform first scan so the wlan interface gets configured (for just-flashed-images)
+        asyncio.run(self.get_wifi_available())
+
         self._settings_manager = Manager("wifi-manager", SettingsV1)
         self._settings_manager.load()
         try:


### PR DESCRIPTION
When a raspbian image is flashed, the wlan interface is not configured until it receives an initial request. If the interface is not configured, the hotspot does not work correctly. To force the initial configuration, we perform an initial scan.

Tested with a freshy-flashed image. Now working flawlessly.

Fix #1097 