### PR TITLE
version-chooser: Allow for newer versions of `werkzeug`

### DIFF
--- a/core/services/versionchooser/setup.py
+++ b/core/services/versionchooser/setup.py
@@ -53,7 +53,7 @@ setup(
         "appdirs == 1.4.4",
         "pytest-asyncio == 0.14.0",
         "asyncmock == 0.4.2",
-        "werkzeug == 2.0.0",
+        "werkzeug >= 2.0.0",
         "attrs == 20.3.0",
         "jinja2 == 3.0.3",
         "itsdangerous == 2.1.1",


### PR DESCRIPTION
This is needed to fullfill the [installation requirements](https://github.com/bluerobotics/BlueOS-docker/runs/7622218531?check_suite_focus=true#step:7:6879). We (@Williangalvani) need to make sure this doesn't break anything (from semver, it should not).