### PR TITLE
beacon: Change mdns for hotspot interface

### DIFF
--- a/core/services/beacon/default-settings.json
+++ b/core/services/beacon/default-settings.json
@@ -21,7 +21,7 @@
       },
       {
         "name": "uap0",
-        "domain_names": ["blueos-wifi"],
+        "domain_names": ["blueos-hotspot"],
         "advertise": ["_http"],
         "ip": "ips[0]"
       }


### PR DESCRIPTION
Uses `blueos-hotspot.local` to prevent conflicts with wifi-client network.