### PR TITLE
beacon: Warn users about usage of hotspot connection

### DIFF
--- a/core/frontend/src/components/beacon/BeaconTrayMenu.vue
+++ b/core/frontend/src/components/beacon/BeaconTrayMenu.vue
@@ -74,7 +74,7 @@ export default Vue.extend({
       return beacon.available_domains.filter((entry) => entry.interface_type === InterfaceType.WIRED)
     },
     wireless_interface_domains(): Domain[] {
-      return beacon.available_domains.filter((entry) => entry.interface_type === InterfaceType.WIFI)
+      return beacon.available_domains.filter((entry) => entry.interface_type !== InterfaceType.WIRED)
     },
     is_connected_to_wifi(): boolean {
       return this.wireless_interface_domains.some((domain) => domain.ip === beacon.nginx_ip_address)

--- a/core/frontend/src/types/beacon.ts
+++ b/core/frontend/src/types/beacon.ts
@@ -1,6 +1,7 @@
 export enum InterfaceType {
   WIRED = 'WIRED',
   WIFI = 'WIFI',
+  HOTSPOT = 'HOTSPOT',
   UNKNOWN = 'UNKNOWN',
 }
 export interface Domain {

--- a/core/services/beacon/typedefs.py
+++ b/core/services/beacon/typedefs.py
@@ -6,12 +6,15 @@ from pydantic import BaseModel
 class InterfaceType(str, Enum):
     WIRED = "WIRED"
     WIFI = "WIFI"
+    HOTSPOT = "HOTSPOT"
     UNKNOWN = "UNKNOWN"
 
     @staticmethod
     def guess_from_name(name: str) -> "InterfaceType":
         if name.startswith("wl"):
             return InterfaceType.WIFI
+        if name.startswith("uap"):
+            return InterfaceType.HOTSPOT
         if name.startswith("en"):
             return InterfaceType.WIRED
         if name.startswith("eth"):


### PR DESCRIPTION
Make sure they know this should not be their main connection, the same way we advertise it for client-wifi connections.

Fix #1106 

~(didn't test yet)~