### PR TITLE
core: services: helper: Cache detect_service output

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import http
+from functools import cache
 from pathlib import Path
 from typing import Any, List, Optional
 
@@ -45,7 +46,7 @@ class Helper:
     LOCALSERVER_CANDIDATES = ["0.0.0.0", "::"]
 
     @staticmethod
-    @temporary_cache(timeout_seconds=60)
+    @cache
     def detect_service(port: int) -> ServiceInfo:
         info = ServiceInfo(valid=False, title="Unknown", documentation_url="", versions=[], port=port)
 


### PR DESCRIPTION
Fix #1115

- There is no reason to not cache it without timeout.
- There is no way for us to check where is the swagger website without probing the valid paths.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>