### PR TITLE
Update mavlink camera manager

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -227,6 +227,7 @@ class ArduPilotManager(metaclass=Singleton):
                 5777,
                 persistent=True,
                 protected=True,
+                overwrite_settings=True,
             ),
             Endpoint(
                 "Ping360 Heading",

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -222,9 +222,9 @@ class ArduPilotManager(metaclass=Singleton):
             Endpoint(
                 "Internal Link",
                 self.settings.app_name,
-                EndpointType.UDPServer,
+                EndpointType.TCPServer,
                 "127.0.0.1",
-                14001,
+                5777,
                 persistent=True,
                 protected=True,
             ),

--- a/core/services/ardupilot_manager/mavlink_proxy/AbstractRouter.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/AbstractRouter.py
@@ -131,11 +131,14 @@ class AbstractRouter(metaclass=abc.ABCMeta):
     def add_endpoint(self, endpoint: Endpoint) -> None:
         self._validate_endpoint(endpoint)
 
-        if endpoint in self._endpoints:
-            raise EndpointAlreadyExists(f"Endpoint '{endpoint}' already exists.")
-
-        if endpoint.name in [endpoint.name for endpoint in self._endpoints]:
-            raise DuplicateEndpointName(f"Name '{endpoint.name}' already being used by an existing endpoint.")
+        for current_endpoint in self._endpoints:
+            if endpoint == current_endpoint:
+                raise EndpointAlreadyExists(f"Endpoint '{endpoint}' already exists.")
+            if endpoint.name == current_endpoint.name:
+                if endpoint.overwrite_settings:
+                    self._endpoints.remove(current_endpoint)
+                    break
+                raise DuplicateEndpointName(f"Name '{endpoint.name}' already being used by an existing endpoint.")
 
         self._endpoints.add(endpoint)
 

--- a/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/Endpoint.py
@@ -20,6 +20,7 @@ class Endpoint:
     persistent: Optional[bool] = False
     protected: Optional[bool] = False
     enabled: Optional[bool] = True
+    overwrite_settings: Optional[bool] = False
 
     @root_validator
     @classmethod

--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
@@ -62,11 +62,10 @@ class MAVLinkRouter(AbstractRouter):
             )
 
         if master_endpoint.connection_type == EndpointType.TCPServer:
-            # The "--tcp-port 0" argument is used to prevent the router from binding TCP port 5760
             return f"{self.binary()} \
-                --tcp-endpoint {master_endpoint.place}:{master_endpoint.argument} --tcp-port 0 {endpoints}"
+                --tcp-endpoint {master_endpoint.place}:{master_endpoint.argument} {endpoints}"
 
-        return f"{self.binary()} {master_endpoint.place}:{master_endpoint.argument} --tcp-port 0 {endpoints}"
+        return f"{self.binary()} {master_endpoint.place}:{master_endpoint.argument} {endpoints}"
 
     @staticmethod
     def name() -> str:

--- a/core/services/ardupilot_manager/mavlink_proxy/test_all.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/test_all.py
@@ -64,6 +64,7 @@ def test_endpoint() -> None:
         "persistent": False,
         "protected": False,
         "enabled": True,
+        "overwrite_settings": False,
     }, "Endpoint dict does not match."
 
 

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -31,7 +31,7 @@ SERVICES=(
     'commander',"$SERVICES_PATH/commander/main.py"
     'nmea_injector',"$SERVICES_PATH/nmea_injector/nmea_injector/main.py"
     'helper',"$SERVICES_PATH/helper/main.py"
-    'video',"mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --verbose"
+    'video',"mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --log-path /var/logs/blueos/mavlink-camera-manager --verbose"
     'mavlink2rest',"mavlink2rest --connect=udpin:127.0.0.1:14000 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
     'linux2rest',"linux2rest"
     'filebrowser',"filebrowser --database /etc/filebrowser/filebrowser.db --baseurl /file-browser"

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -31,7 +31,7 @@ SERVICES=(
     'commander',"$SERVICES_PATH/commander/main.py"
     'nmea_injector',"$SERVICES_PATH/nmea_injector/nmea_injector/main.py"
     'helper',"$SERVICES_PATH/helper/main.py"
-    'video',"mavlink-camera-manager --default-settings BlueROVUDP  --mavlink udpout:127.0.0.1:14001 --verbose"
+    'video',"mavlink-camera-manager --default-settings BlueROVUDP --mavlink udpout:127.0.0.1:14001 --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --verbose"
     'mavlink2rest',"mavlink2rest --connect=udpin:127.0.0.1:14000 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
     'linux2rest',"linux2rest"
     'filebrowser',"filebrowser --database /etc/filebrowser/filebrowser.db --baseurl /file-browser"

--- a/core/start-blueos-core
+++ b/core/start-blueos-core
@@ -31,7 +31,7 @@ SERVICES=(
     'commander',"$SERVICES_PATH/commander/main.py"
     'nmea_injector',"$SERVICES_PATH/nmea_injector/nmea_injector/main.py"
     'helper',"$SERVICES_PATH/helper/main.py"
-    'video',"mavlink-camera-manager --default-settings BlueROVUDP --mavlink udpout:127.0.0.1:14001 --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --verbose"
+    'video',"mavlink-camera-manager --default-settings BlueROVUDP --mavlink tcpout:127.0.0.1:5777 --gst-feature-rank omxh264enc=0,v4l2h264enc=250,x264enc=260 --verbose"
     'mavlink2rest',"mavlink2rest --connect=udpin:127.0.0.1:14000 --server 0.0.0.0:6040 --system-id $MAV_SYSTEM_ID --component-id $MAV_COMPONENT_ID_ONBOARD_COMPUTER4"
     'linux2rest',"linux2rest"
     'filebrowser',"filebrowser --database /etc/filebrowser/filebrowser.db --baseurl /file-browser"

--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink-camera-manager"
 ARTIFACT_PREFIX="mavlink-camera-manager"
-VERSION=t3.6.2
+VERSION=t3.8.2
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/bluerobotics/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-armv7.zip"


### PR DESCRIPTION
docker image: `joaoantoniocardoso/blueos-core:update-mavlink-camera-manager`

- [x] Tested with pixhawk
- [x] Tested with SITL

Summary:
- RTSP is working again
- WebRTC is working again
- Improved QGC integration: multiple streams are working with QGC
- Logging to daily-rotating files (`/var/logs/mavlink-camera-manager/.`)