### PR TITLE
CI: test-and-deploy: Move python version from list to value

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -15,18 +15,17 @@ jobs:
   python-tests:
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        python-version: [3.9] # Our base image has Python 3.9
+    env:
+      python-version: 3.9 # Our base image has Python 3.9
 
     steps:
     - name: Checkout
       uses: actions/checkout@v2
 
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ env.python-version }}
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: ${{ env.python-version }}
 
     - name: Install dependencies
       run: |


### PR DESCRIPTION
Just to have it showing as a number and not under a droplist in GitHub

Now:
![image](https://user-images.githubusercontent.com/1215497/186932413-b5ecfce5-11bf-4cfa-ad91-6a8177543ae0.png)
Before:
![image](https://user-images.githubusercontent.com/1215497/186932479-0d90891b-8436-4022-885c-3738e9c5178f.png)


Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>