### PR TITLE
core: tools: logviewer: bump version to 0.9.9

### DIFF
--- a/core/tools/logviewer/bootstrap.sh
+++ b/core/tools/logviewer/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 DESTINATION_PATH="/home/pi/tools/logviewer"
 
-VERSION=v0.9.8
+VERSION=v0.9.9
 
 REMOTE_URL="https://github.com/Ardupilot/UAVLogViewer/releases/download/${VERSION}/logviewer.tar.gz"
 


### PR DESCRIPTION
This updates the cesium Ion token, and it's required for the maps to work.

full changelog:
https://github.com/ArduPilot/UAVLogViewer/releases/tag/v0.9.9

~image coming soon to a docker hub near you.~

image (including #1136) is available at williangalvani/blueos-core:fixlogviewer2