### PR TITLE
Update mavlink camera manager to t3.9.0

### DIFF
--- a/core/tools/hotspot/bootstrap.sh
+++ b/core/tools/hotspot/bootstrap.sh
@@ -5,6 +5,7 @@ set -e
 
 # Hostapd turns a network wireless interface into a wifi hotspot
 echo "Installing hostapd."
+apt update
 apt install -y --no-install-recommends hostapd
 
 # Iw and net-tools are used by the hotspot manager to configure the network interfaces

--- a/core/tools/linux2rest/bootstrap.sh
+++ b/core/tools/linux2rest/bootstrap.sh
@@ -13,6 +13,6 @@ if [[ "$(uname -m)" == "x86_64"* ]]; then
 fi
 
 # Download and install necessary libraries for linux2rest
-DEBIAN_FRONTEND=noninteractive apt --yes install libudev-dev
+DEBIAN_FRONTEND=noninteractive apt update && apt install -y libudev-dev
 wget "$REMOTE_BINARY_URL" -O "$LOCAL_BINARY_PATH"
 chmod +x "$LOCAL_BINARY_PATH"

--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink-camera-manager"
 ARTIFACT_PREFIX="mavlink-camera-manager"
-VERSION=t3.8.2
+VERSION=t3.9.0
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/bluerobotics/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-armv7.zip"


### PR DESCRIPTION
This PR Updates mavlink-camera-manager to [t3.9.0](https://github.com/bluerobotics/mavlink-camera-manager/releases/tag/t3.9.0)

- [ ] Tested on Raspberry Pi 4
