### PR TITLE
core: beacon: revert to default settings if settings file fails to load

### DIFF
--- a/core/services/beacon/settings.py
+++ b/core/services/beacon/settings.py
@@ -172,7 +172,7 @@ class SettingsV3(SettingsV2):
         try:
             if not any(interface["name"] == "uap0" for interface in data["interfaces"]):
                 data["interfaces"].append(
-                    Interface(name="uap0", domain_names=["blueos-hotspot"], advertise=["_http"], ip="ips[0]")
+                    Interface(name="uap0", domain_names=["blueos-hotspot"], advertise=["_http"], ip="ips[0]").as_dict()
                 )
         except Exception as e:
             logger.error(f"unable to update SettingsV2 to SettingsV3: {e}")


### PR DESCRIPTION
This makes sure that if something goes wrong while loading the settings, we still have beacon operating.