### PR TITLE
core: frotnend: video: Increase timeout of reset settings

### DIFF
--- a/core/frontend/src/store/video.ts
+++ b/core/frontend/src/store/video.ts
@@ -126,7 +126,7 @@ class VideoStore extends VuexModule {
       params: {
         all: true,
       },
-      timeout: 1000,
+      timeout: 5000,
     })
       .then(() => {
         message_manager.emitMessage(MessageLevel.Success, 'Stream configuration set to factory default')


### PR DESCRIPTION
From our tests it can take up to 2.5s.
Going to use 5s for worst case scenario.

Fix #1171

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>