### PR TITLE
core: use BUILDPLATFORM for building the frontend

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -1,5 +1,5 @@
 # Build frontend
-FROM node:16-buster-slim AS frontendBuilder
+FROM --platform=$BUILDPLATFORM node:16-buster-slim AS frontendBuilder
 
 ARG VUE_APP_GIT_DESCRIBE
 RUN [ -z "$VUE_APP_GIT_DESCRIBE" ] \


### PR DESCRIPTION
This should improve performance when the frontend is the only thing changed.
It makes the fronted stage use the current architecture, which doesn't change the final result, which is a bunch of html/js/css files