### PR TITLE
ardupilot-manager: Send first found firmware candidate when multiple exist

### DIFF
--- a/core/services/ardupilot_manager/firmware/FirmwareDownload.py
+++ b/core/services/ardupilot_manager/firmware/FirmwareDownload.py
@@ -17,7 +17,6 @@ from exceptions import (
     FirmwareDownloadFail,
     InvalidManifest,
     ManifestUnavailable,
-    MoreThanOneCandidate,
     NoCandidate,
     NoVersionAvailable,
 )
@@ -208,7 +207,7 @@ class FirmwareDownloader:
             )
 
         if len(items) != 1:
-            raise MoreThanOneCandidate(f"Found a number of candidates different of one ({len(items)}): {items}.")
+            logger.warning(f"Found a number of candidates different of one ({len(items)}): {items}.")
 
         item = items[0]
         logger.debug(f"Downloading following firmware: {item}")


### PR DESCRIPTION
Current behavior was to raise, but that prevent firmware to be downloaded.

Core team agreed it's better to have one than to have nothing, so we go on with the first candidate and log a warning message about the problem.

This is experienced for ArduCopter firmware, since it has both "regular" and "heli" firmware available in the same repo.

Image building and testing is in progress.

Fix #1153 