### PR TITLE
core: helper: only cache successful probes

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import http
-from functools import cache
 from pathlib import Path
 from typing import Any, List, Optional
 
@@ -46,7 +45,7 @@ class Helper:
     LOCALSERVER_CANDIDATES = ["0.0.0.0", "::"]
 
     @staticmethod
-    @cache
+    @temporary_cache(timeout_seconds=60)  # a temporary cache helps us deal with changes in metadata
     def detect_service(port: int) -> ServiceInfo:
         info = ServiceInfo(valid=False, title="Unknown", documentation_url="", versions=[], port=port)
 


### PR DESCRIPTION
The goal here is to improve detection of Extensions, which sometimes get cached as an invalid service before they get up properly.

Not quite sure about this one. I Think the best thing to do would be to have a timeout. Say keep probing it for 1 minute, and then give up. but what if something takes longer than a minute to respond?
Also, what if something REALLY dislikes being probed?