### PR TITLE
core: ArdupilotManager: support streaming dataflash logs with mavlink-router

### DIFF
--- a/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
+++ b/core/services/ardupilot_manager/mavlink_proxy/MAVLinkRouter.py
@@ -65,7 +65,7 @@ class MAVLinkRouter(AbstractRouter):
             return f"{self.binary()} \
                 --tcp-endpoint {master_endpoint.place}:{master_endpoint.argument} {endpoints}"
 
-        return f"{self.binary()} {master_endpoint.place}:{master_endpoint.argument} {endpoints}"
+        return f"{self.binary()} {master_endpoint.place}:{master_endpoint.argument} {endpoints} -l {self.logdir()}"
 
     @staticmethod
     def name() -> str:


### PR DESCRIPTION
needs testing.
needs LOG_BACKEND to be set to enable MAVLINK backend

it seemed to create some 0 bytes files in my tests, but the correct ones are generated as well. we could do a routing to erase these empty files..