### PR TITLE
Add rate-limiting to parameter store

### DIFF
--- a/core/frontend/src/types/autopilot/parameter-fetcher.ts
+++ b/core/frontend/src/types/autopilot/parameter-fetcher.ts
@@ -17,6 +17,10 @@ export default class ParameterFetcher {
 
   watchdog_last_count = 0
 
+  last_store_update = performance.now()
+
+  min_update_interval_ms = 300
+
   constructor() {
     this.setupWs()
   }
@@ -36,9 +40,14 @@ export default class ParameterFetcher {
     if (!this.store) {
       return
     }
-    this.store.setParameters(this.parameter_table.parameters())
-    this.store.setLoadedParametersCount(this.loaded_params_count)
-    this.store.setTotalParametersCount(this.total_params_count ?? 0)
+    const enough_time_passed = performance.now() - this.last_store_update > this.min_update_interval_ms
+    const all_parameters_loaded = this.loaded_params_count === this.total_params_count
+    if (enough_time_passed || all_parameters_loaded) {
+      this.store.setParameters(this.parameter_table.parameters())
+      this.store.setLoadedParametersCount(this.loaded_params_count)
+      this.store.setTotalParametersCount(this.total_params_count ?? 0)
+      this.last_store_update = performance.now()
+    }
   }
 
   requestParamsWatchdog(): void {

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -86,7 +86,10 @@
           >
             <v-card>
               <v-card-title class="pb-0 ">
-                {{ extension.name.split('/')[1] }} <span class="ml-3" style="color: grey;"> {{ extension.tag }}</span>
+                {{ extension.name.split('/')[1] }} <span
+                  class="ml-3"
+                  style="color: grey;"
+                > {{ extension.tag }}</span>
               </v-card-title>
               <span class="mt-0 mb-4 ml-4 text--disabled">{{ extension.name }}</span>
               <v-card-text width="50%">


### PR DESCRIPTION
This helps Vue DevTools to cope with the parameters functionality, as the high number of mutations was making it freeze.

If we still don't have all the parameters download, this rate-limits store updates to at most one update every 300ms. after they are all loaded, the reate limiter is disabled.

The issue didn't seem to affect the production build, but made debugging anything in blueos frontend very painful

docker at williangalvani/blueos-core:ratelimit