### PR TITLE
core: frontend: components: parameter-editor: Show 'None' over '0' when nothing is selected

### DIFF
--- a/core/frontend/src/components/parameter-editor/ParameterEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditor.vue
@@ -303,6 +303,10 @@ export default Vue.extend({
         && re.test(value)
     },
     printParam(param: Parameter): string {
+      if ((param.bitmask || param.options) && param.value === 0) {
+        return 'None'
+      }
+
       if (param.options && param.value in param.options) {
         // TODO: fix this so it doesnt show text for values such as 2.5 (rounding down to 2)
         return param.options[param.value]


### PR DESCRIPTION
Now:
![image](https://user-images.githubusercontent.com/1215497/203164007-ee385e7a-3863-4788-b386-56e855f0b7d1.png)

Before:
![image](https://user-images.githubusercontent.com/1215497/203164061-936560e7-d5b9-4774-8063-a628532d3bd8.png)



Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>