### PR TITLE
eslintrc: Add import/resolver to include json files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -65,4 +65,11 @@ module.exports = {
     'vue/valid-v-slot': ['error', { allowModifiers: true }],
     'no-await-in-loop': 'off',
   },
+  settings: {
+    'import/resolver': {
+      node: {
+        extensions: ['.js', '.json', '.jsx', '.ts', '.tsx'],
+      },
+    },
+  },
 }


### PR DESCRIPTION
If that's not included, `yarn serve` just fails to find the json files.

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>