### PR TITLE
core: frontend: dev-server: allow proxying chunked responses

### DIFF
--- a/core/frontend/vue.config.js
+++ b/core/frontend/vue.config.js
@@ -36,6 +36,15 @@ module.exports = {
       },
       '^/kraken': {
         target: SERVER_ADDRESS,
+        selfHandleResponse: true,
+        onProxyRes: (proxyRes, request, response) => {
+          proxyRes.on('data', (data) => {
+            response.write(data);
+          });
+          proxyRes.on('end', () => {
+            response.end();
+          });
+        }
       },
       '^/nmea-injector': {
         target: SERVER_ADDRESS,
@@ -63,6 +72,15 @@ module.exports = {
       },
       '^/version-chooser': {
         target: SERVER_ADDRESS,
+        selfHandleResponse: true,
+        onProxyRes: (proxyRes, request, response) => {
+          proxyRes.on('data', (data) => {
+            response.write(data);
+          });
+          proxyRes.on('end', () => {
+            response.end();
+          });
+        }
       },
       '^/wifi-manager': {
         target: SERVER_ADDRESS,


### PR DESCRIPTION
This allows us to see progress of docker pull operations in the dev server. previously, they were being held and outputted all at once at the end of the response.

based on https://github.com/webpack/webpack-dev-server/issues/1742#issuecomment-483970770