### PR TITLE
core: components: parameter-editor: Fix options with value 0

### DIFF
--- a/core/frontend/src/components/parameter-editor/ParameterEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditor.vue
@@ -305,7 +305,7 @@ export default Vue.extend({
         && re.test(value)
     },
     printParam(param: Parameter): string {
-      if ((param.bitmask || param.options) && param.value === 0) {
+      if ((param.bitmask || param.options === undefined) && param.value === 0) {
         return 'None'
       }
 


### PR DESCRIPTION
A parameter such as `EK2_ENABLE` can have a value of `0`, and that's `DISABLE` option

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>