### PR TITLE
parameter-editor: Improve loading information

### DIFF
--- a/core/frontend/src/store/autopilot.ts
+++ b/core/frontend/src/store/autopilot.ts
@@ -28,11 +28,14 @@ class AutopilotStore extends VuexModule {
 
   finished_loading = false
 
+  metadata_loaded = false
+
   @Mutation
   reset(): void {
     this.parameters = []
     parameterFetcher.reset()
     this.finished_loading = false
+    this.metadata_loaded = false
     this.parameters_loaded = 0
     this.parameters_total = 0
   }
@@ -43,15 +46,21 @@ class AutopilotStore extends VuexModule {
   }
 
   @Mutation
+  setMetadataLoaded(loaded: boolean): void {
+    this.metadata_loaded = loaded
+    this.finished_loading = this.parameters_loaded >= this.parameters_total && this.metadata_loaded
+  }
+
+  @Mutation
   setLoadedParametersCount(count: number): void {
     this.parameters_loaded = count
-    this.finished_loading = this.parameters_loaded >= this.parameters_total
+    this.finished_loading = this.parameters_loaded >= this.parameters_total && this.metadata_loaded
   }
 
   @Mutation
   setTotalParametersCount(count: number): void {
     this.parameters_total = count
-    this.finished_loading = this.parameters_loaded >= this.parameters_total
+    this.finished_loading = this.parameters_loaded >= this.parameters_total && this.metadata_loaded
   }
 }
 

--- a/core/frontend/src/types/autopilot/parameter-fetcher.ts
+++ b/core/frontend/src/types/autopilot/parameter-fetcher.ts
@@ -80,9 +80,6 @@ export default class ParameterFetcher {
 
   setupWs(): void {
     this.listener.setCallback((receivedMessage) => {
-      if (receivedMessage.count > 0) {
-        this.parameter_table.setCount(receivedMessage.count)
-      }
       const param_name = receivedMessage.message.param_id.join('').replace(/\0/g, '')
       const { param_index, param_value, param_type } = receivedMessage.message
       // We need this due to mismatches between js 64-bit floats and REAL32 in MAVLink

--- a/core/frontend/src/types/autopilot/parameter-fetcher.ts
+++ b/core/frontend/src/types/autopilot/parameter-fetcher.ts
@@ -37,11 +37,11 @@ export default class ParameterFetcher {
   }
 
   updateStore(): void {
-    if (!this.store) {
+    if (!this.store || this.total_params_count === null) {
       return
     }
     const enough_time_passed = performance.now() - this.last_store_update > this.min_update_interval_ms
-    const all_parameters_loaded = this.loaded_params_count === this.total_params_count
+    const all_parameters_loaded = this.loaded_params_count >= this.total_params_count
     if (enough_time_passed || all_parameters_loaded) {
       this.store.setParameters(this.parameter_table.parameters())
       this.store.setLoadedParametersCount(this.loaded_params_count)
@@ -51,7 +51,9 @@ export default class ParameterFetcher {
   }
 
   requestParamsWatchdog(): void {
-    if (this.loaded_params_count > 0 && this.loaded_params_count === this.total_params_count) {
+    if (this.total_params_count !== null
+      && this.loaded_params_count > 0
+      && this.loaded_params_count >= this.total_params_count) {
       return
     }
     if (this.loaded_params_count > this.watchdog_last_count) {

--- a/core/frontend/src/types/autopilot/parameter-fetcher.ts
+++ b/core/frontend/src/types/autopilot/parameter-fetcher.ts
@@ -43,6 +43,7 @@ export default class ParameterFetcher {
     const enough_time_passed = performance.now() - this.last_store_update > this.min_update_interval_ms
     const all_parameters_loaded = this.loaded_params_count >= this.total_params_count
     if (enough_time_passed || all_parameters_loaded) {
+      this.store.setMetadataLoaded(this.parameter_table.loaded())
       this.store.setParameters(this.parameter_table.parameters())
       this.store.setLoadedParametersCount(this.loaded_params_count)
       this.store.setTotalParametersCount(this.total_params_count ?? 0)
@@ -108,6 +109,15 @@ export default class ParameterFetcher {
       }
       this.updateStore()
     }).setFrequency(0)
-    setInterval(() => { this.requestParamsWatchdog() }, 2000)
+    setInterval(() => {
+      this.requestParamsWatchdog()
+
+      // Check if store is done, otherwise try to update it
+      // The parameter metadata may not be completed or
+      // others edge cases
+      if (this.store?.finished_loading !== true) {
+        this.updateStore()
+      }
+    }, 2000)
   }
 }

--- a/core/frontend/src/types/autopilot/parameter-fetcher.ts
+++ b/core/frontend/src/types/autopilot/parameter-fetcher.ts
@@ -104,7 +104,7 @@ export default class ParameterFetcher {
         if (receivedMessage.message.param_count) {
           this.total_params_count = receivedMessage.message.param_count
         }
-        this.loaded_params_count += 1
+        this.loaded_params_count = this.parameter_table.size()
       }
       this.updateStore()
     }).setFrequency(0)

--- a/core/frontend/src/types/autopilot/parameter-table.ts
+++ b/core/frontend/src/types/autopilot/parameter-table.ts
@@ -105,4 +105,8 @@ export default class ParametersTable {
     parameters(): Parameter[] {
       return Object.values(this.parametersDict)
     }
+
+    size(): number {
+      return this.parameters().length
+    }
 }

--- a/core/frontend/src/types/autopilot/parameter-table.ts
+++ b/core/frontend/src/types/autopilot/parameter-table.ts
@@ -37,6 +37,8 @@ interface MetadataFile {
 export default class ParametersTable {
     parametersDict: {[key: number] : Parameter} = {}
 
+    metadata_loaded = false
+
     metadata = {} as Dictionary<Metadata>
 
     constructor() {
@@ -73,6 +75,15 @@ export default class ParametersTable {
           this.metadata[name] = parameter
         }
       }
+
+      this.updateParameters()
+      this.metadata_loaded = true
+    }
+
+    updateParameters(): void {
+      for (const parameter of Object.values(this.parametersDict)) {
+        this.addParam(parameter)
+      }
     }
 
     addParam(param: Parameter): void {
@@ -108,5 +119,9 @@ export default class ParametersTable {
 
     size(): number {
       return this.parameters().length
+    }
+
+    loaded(): boolean {
+      return this.metadata_loaded
     }
 }

--- a/core/frontend/src/types/autopilot/parameter-table.ts
+++ b/core/frontend/src/types/autopilot/parameter-table.ts
@@ -37,8 +37,6 @@ interface MetadataFile {
 export default class ParametersTable {
     parametersDict: {[key: number] : Parameter} = {}
 
-    count = 0
-
     metadata = {} as Dictionary<Metadata>
 
     constructor() {
@@ -47,7 +45,6 @@ export default class ParametersTable {
 
     reset(): void {
       this.parametersDict = {}
-      this.count = 0
     }
 
     fetchMetadata(): void {
@@ -103,10 +100,6 @@ export default class ParametersTable {
         return
       }
       this.parametersDict[parseInt(index[0], 10)].value = param_value
-    }
-
-    setCount(count: number): void {
-      this.count = count
     }
 
     parameters(): Parameter[] {


### PR DESCRIPTION
Should be merged after #1252 

- Tracks both parameter metadata and vehicle parameter.
- Use v-data-table loading object over our own.


https://user-images.githubusercontent.com/1215497/205342234-82695cf9-27ab-40fe-a4bb-7ad2f69f25b1.mov


