### PR TITLE
install: boards: Use sed over truncate to add cgroups

### DIFF
--- a/install/README.md
+++ b/install/README.md
@@ -16,8 +16,6 @@ To use a different remote or version, you can se the following environment varia
 Remember that to do that, you need to set the environment variables as root:
 ```sh
 sudo su
-export VERSION=example-version
-export REMOTE=https://raw.githubusercontent.com/patrickelectric/blueos-docker
-# You can also change the install URL to use a different source for the install script
-curl -fsSL https://raw.githubusercontent.com/patrickelectric/blueos-docker/example-version/install/install.sh | bash
+# You can also change the install URL to use a different source for files
+curl -fsSL https://raw.githubusercontent.com/patrickelectric/blueos-docker/example-version/install/install.sh | export REMOTE=https://raw.githubusercontent.com/patrickelectric/blueos-docker export VERSION=example-version bash
 ```

--- a/install/boards/bcm_27xx.sh
+++ b/install/boards/bcm_27xx.sh
@@ -70,8 +70,8 @@ sudo sed -e 's/console=serial[0-9],[0-9]*\ //' -i $CMDLINE_FILE
 # Set cgroup, necessary for docker access to memory information
 echo "- Enable cgroup with memory and cpu"
 grep -q cgroup $CMDLINE_FILE || (
-    truncate --size -1 $CMDLINE_FILE
-    echo " cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory" >> $CMDLINE_FILE
+    # Append cgroups on the first line
+    sed -i '1 s/$/ cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory/' $CMDLINE_FILE
 )
 
 # Update raspberry pi firmware

--- a/install/boards/bcm_28xx.sh
+++ b/install/boards/bcm_28xx.sh
@@ -35,6 +35,6 @@ sudo sed -e 's/console=serial[0-9],[0-9]*\ //' -i $CMDLINE_FILE
 # Set cgroup, necessary for docker access to memory information
 echo "- Enable cgroup with memory and cpu"
 grep -q cgroup $CMDLINE_FILE || (
-    truncate --size -1 $CMDLINE_FILE
-    echo " cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory" >> $CMDLINE_FILE
+    # Append cgroups on the first line
+    sed -i '1 s/$/ cgroup_enable=cpuset cgroup_memory=1 cgroup_enable=memory/' $CMDLINE_FILE
 )

--- a/install/install.sh
+++ b/install/install.sh
@@ -73,9 +73,9 @@ ARCHITECTURE="$(uname -m)"
 # Check if the script is running as root
 [[ $EUID != 0 ]] && echo "Script must run as root."  && exit 1
 
-echo "Checking if network and remote are available."
+echo "Checking if network and remote are available: $ROOT"
 curl -fsSL --silent $ROOT/install/install.sh 1> /dev/null || (
-    echo "Remote is not available: ${ROOT}"
+    echo "Remote is not available or install.sh does not exist: ${ROOT}"
     exit 1
 )
 


### PR DESCRIPTION
Truncate can remove characters of files that does not have a line break.
Sed can add the text on the first line without problems.

Fix #1260 

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>