### PR TITLE
Show allowed CPU and Memory budget for extensions

### DIFF
--- a/core/frontend/src/components/system-information/SystemCondition.vue
+++ b/core/frontend/src/components/system-information/SystemCondition.vue
@@ -18,6 +18,7 @@ import Vue from 'vue'
 import SystemConditionCard from '@/components/system-information/SystemConditionCard.vue'
 import system_information, { FetchType } from '@/store/system-information'
 import { Disk } from '@/types/system-information/system'
+import { prettifySize } from '@/utils/helper_functions'
 
 export default Vue.extend({
   name: 'SystemCondition',
@@ -52,18 +53,13 @@ export default Vue.extend({
     memory(): Record<string, unknown> {
       const memory = system_information.system?.memory
 
-      const used_ram_memory = memory
-        ? memory.ram.used_kB / 2 ** 20 : 0
-      const total_ram_memory = memory
-        ? memory.ram.total_kB / 2 ** 20 : 0
+      const used_ram_memory = memory?.ram?.used_kB ?? 0
+      const total_ram_memory = memory?.ram?.total_kB ?? 0
+      const used_swap_memory = memory?.swap?.used_kB ?? 0
+      const total_swap_memory = memory?.swap?.total_kB ?? 0
 
-      const used_swap_memory = memory
-        ? memory.swap.used_kB / 2 ** 20 : 0
-      const total_swap_memory = memory
-        ? memory.swap.total_kB / 2 ** 20 : 0
-
-      const memory_text = `RAM: ${used_ram_memory.toFixed(3)}GB/${total_ram_memory.toFixed(3)}GB`
-        + `<br/>SWAP: ${used_swap_memory.toFixed(3)}GB/${total_swap_memory.toFixed(3)}GB`
+      const memory_text = `RAM: ${prettifySize(used_ram_memory)}/${prettifySize(total_ram_memory)}`
+        + `<br/>SWAP: ${prettifySize(used_swap_memory)}/${prettifySize(total_swap_memory)}`
 
       return {
         name: 'Memory',

--- a/core/frontend/src/utils/helper_functions.ts
+++ b/core/frontend/src/utils/helper_functions.ts
@@ -63,3 +63,18 @@ export function convertGitDescribeToUrl(git_describe: string): string {
   const hash = git_describe.slice(git_describe.length - 7)
   return `${project_url}/tree/${hash}`
 }
+
+export function prettifySize(size_kb: number): string {
+  if (Number.isNaN(size_kb)) {
+    return 'N/A'
+  }
+  if (size_kb < 1024) {
+    return `${size_kb.toFixed(1)} KB`
+  }
+  const size_mb = size_kb / 1024
+  if (size_mb < 1024) {
+    return `${size_mb.toFixed(1)} MB`
+  }
+  const size_gb = size_mb / 1024
+  return `${size_gb.toFixed(1)} GB`
+}

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -108,10 +108,10 @@
                             color="green"
                             height="25"
                           >
-                            <template #default="{ value }">
+                            <template #default>
                               <strong v-if="getMemoryUsage(extension).toFixed">
-                                {{`${(value*total_memory).toFixed(1)} MB`}}
-                                {{`/ ${(getMemoryLimit(extension)*0.01*total_memory*1024).toFixed(0)} MB` }}
+                                {{ prettifySize(getMemoryUsage(extension)*total_memory*0.01) }} /
+                                {{ prettifySize(getMemoryLimit(extension)*total_memory*0.01) }}
                               </strong>
                               <strong v-else>
                                 N/A
@@ -269,6 +269,7 @@ import settings from '@/libs/settings'
 import system_information from '@/store/system-information'
 import { kraken_service } from '@/types/frontend_services'
 import back_axios from '@/utils/api'
+import { prettifySize } from '@/utils/helper_functions'
 import PullTracker from '@/utils/pull_tracker'
 
 import { ExtensionData, InstalledExtensionData, RunningContainer } from '../types/kraken'
@@ -312,9 +313,9 @@ export default Vue.extend({
       return system_information.system?.cpu?.length ?? 4
     },
     total_memory(): number | undefined {
-      // Total system memory in GB
+      // Total system memory in kB
       const total_kb = system_information.system?.memory?.ram?.total_kB
-      return total_kb ? total_kb / 1024 / 1024 : undefined
+      return total_kb ?? undefined
     },
   },
   mounted() {
@@ -327,6 +328,9 @@ export default Vue.extend({
     clearInterval(this.metrics_interval)
   },
   methods: {
+    prettifySize(size_kb: number) {
+      return prettifySize(size_kb)
+    },
     async createOrUpdateExtension(): Promise<void> {
       if (!this.edited_extension) {
         // TODO: error
@@ -405,7 +409,7 @@ export default Vue.extend({
       // Memory limit as a percentage of total system RAM
       const permissions_str = extension.user_permissions ? extension.user_permissions : extension.permissions
       const permissions = JSON.parse(permissions_str)
-      const limit = permissions.HostConfig?.Memory / 1024 / 1024 / 1024 ?? undefined
+      const limit = permissions.HostConfig?.Memory / 1024 ?? undefined
       if (this.total_memory && limit) {
         return limit / this.total_memory / 0.01
       }


### PR DESCRIPTION
example user permissions:
```
{
   "NetworkMode":"host",
   "HostConfig":{
      "CpuPeriod":100000,
      "CpuQuota":20000,
      "Memory":209715200,
      "Privileged":true,
      "NetworkMode":"host",
      "CapAdd":[
         "SYS_ADMIN",
         "NET_ADMIN"
      ],
      "Binds":[
         "/var/lib/zerotier-one:/var/lib/zerotier-one"
      ],
      "Devices":[
         {
            "PathOnHost":"/dev/net/tun",
            "PathInContainer":"/dev/net/tun",
            "CgroupPermissions":"rwm"
         }
      ]
   }
}
```

Example result:
![image](https://user-images.githubusercontent.com/4013804/206539076-0a79bdb7-688c-4bfc-ab92-e4450caef923.png)
