### PR TITLE
parameter editor: Move improvements

### DIFF
--- a/core/frontend/src/components/parameter-editor/ParameterEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditor.vue
@@ -377,7 +377,7 @@ export default Vue.extend({
         && re.test(value)
     },
     printParam(param: Parameter): string {
-      if ((param.bitmask || param.options === undefined) && param.value === 0) {
+      if ((param.bitmask || param.options !== undefined) && param.value === 0) {
         return 'None'
       }
 

--- a/core/frontend/src/components/parameter-editor/ParameterEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditor.vue
@@ -278,6 +278,35 @@ export default Vue.extend({
       return entries.map(([value, name]) => ({ text: name, value: parseFloat(value), disabled: false }))
     },
   },
+  watch: {
+    edit_dialog(): void {
+      if (!this.edit_dialog) {
+        this.forcing_input = false
+        this.custom_input = false
+      }
+
+      // Select force input if value is outside of range initially
+      this.forcing_input = typeof this.isInRange(this.new_value) === 'string'
+
+      // Select custom input if value is outside of possible options
+      this.custom_input = !Object.keys(this.edited_param?.options ?? [])
+        .map((value) => parseFloat(value))
+        .includes(this.new_value)
+    },
+    new_value(): void {
+      // Remove forcing_input once option is inside valid range
+      if (this.forcing_input && typeof this.isInRange(this.new_value) === 'boolean') {
+        this.forcing_input = false
+      }
+
+      // Remove custom once value is known
+      if (this.custom_input) {
+        this.custom_input = !Object.keys(this.edited_param?.options ?? [])
+          .map((value) => parseFloat(value))
+          .includes(this.new_value)
+      }
+    },
+  },
   methods: {
     isInRange(input: number | string): boolean | string {
       // The input value is an empty string when the field is empty

--- a/core/frontend/src/components/parameter-editor/ParameterEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditor.vue
@@ -7,7 +7,7 @@
       :headers="[
         { text: 'Name', value: 'name' },
         { text: 'Description', value: 'description' },
-        { text: 'Value', value: 'value', width: '20px' },
+        { text: 'Value', value: 'value', width: '150px' },
       ]"
       :loading="!finished_loading"
       :items="params"
@@ -49,7 +49,7 @@
         />
       </template>
       <template #item.value="{ item }">
-        {{ printParam(item) }}
+        {{ printParam(item) }} {{ item.units ? `[${item.units}]` : '' }}
       </template>
       <template #footer.prepend>
         <v-btn icon :disabled="!finished_loading" class="mr-5" @click="saveParametersToFile()">

--- a/core/frontend/src/components/parameter-editor/ParameterEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditor.vue
@@ -268,7 +268,7 @@ export default Vue.extend({
       return this.$refs.form as VForm
     },
     show_advanced_checkbox(): boolean {
-      return typeof this.isInRange(this.edited_param?.value ?? 0) === 'string'
+      return typeof this.isInRange(this.new_value ?? 0) === 'string'
     },
     show_custom_checkbox(): boolean {
       return !!(this.edited_param?.options || this.edited_param?.bitmask)

--- a/core/frontend/src/components/parameter-editor/ParameterEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditor.vue
@@ -405,6 +405,12 @@ export default Vue.extend({
       }
 
       try {
+        if (Math.abs(param.value) > 1e4) {
+          return param.value.toExponential()
+        }
+        if (Math.abs(param.value) < 0.01 && param.value !== 0) {
+          return param.value.toExponential()
+        }
         return param.value.toFixed(param.paramType.type.includes('INT') ? 0 : 2)
       } catch {
         return 'N/A'

--- a/core/frontend/src/components/parameter-editor/ParameterEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditor.vue
@@ -123,6 +123,7 @@
                     label="Value"
                     type="number"
                     :step="edited_param.increment ?? 0.01"
+                    :suffix="edited_param.units"
                     :rules="forcing_input ? [] : [isInRange, isValidType]"
                   />
 

--- a/core/frontend/src/types/autopilot/parameter-table.ts
+++ b/core/frontend/src/types/autopilot/parameter-table.ts
@@ -26,6 +26,7 @@ interface Metadata {
   Bitmask?: {[key:number] : string}
   Values?: {[key:number] : string}
   User?: string
+  Units?: string
 }
 
 interface MetadataCategory {
@@ -90,6 +91,7 @@ export default class ParametersTable {
       if (param.name in this.metadata) {
         param.description = this.metadata[param.name].Description?.toTitle() ?? ''
         param.shortDescription = this.metadata[param.name].DisplayName
+        param.units = this.metadata[param.name].Units
         const {
           Values, Bitmask, ReadOnly, Increment, RebootRequired, Range,
         } = this.metadata[param.name]

--- a/core/frontend/src/types/autopilot/parameter.ts
+++ b/core/frontend/src/types/autopilot/parameter.ts
@@ -35,4 +35,6 @@ export default interface Parameter {
     increment?: number
 
     paramType: { type: ParamType }
+
+    units?: string
 }


### PR DESCRIPTION
- Display in scientific units when necessary
- Add units in main viewer and in editor
- Select custom when value does not exist in options once editor is open
- Select force when value is outside range once editor is open
- Deselect custom when value is a know open
- Deselect force when value goes back to range
- Fix reset of force and custom when editor closes

https://user-images.githubusercontent.com/1215497/206581777-d032feb3-d5a7-4bde-9785-33d5b8863ccf.mp4





