### PR TITLE
core: bump pyelftools to 0.28

### DIFF
--- a/core/services/ardupilot_manager/setup.py
+++ b/core/services/ardupilot_manager/setup.py
@@ -84,7 +84,7 @@ setuptools.setup(
         "aiofiles == 0.6.0",
         "loguru == 0.5.3",
         "commonwealth == 0.1.0",
-        "pyelftools == 0.27",
+        "pyelftools == 0.28",
         "psutil == 5.7.2",
         "pyserial == 3.5",
     ],


### PR DESCRIPTION
this could fix this issue where the aarch64 binary is indetified as "ARM" only:
![image (2)](https://user-images.githubusercontent.com/4013804/206585936-2cd4fea1-a483-4fe5-974a-3fb465961f53.png)
