### PR TITLE
core: frontend: components: LogManager: Fix size visualization

### DIFF
--- a/core/frontend/src/components/logs/LogManager.vue
+++ b/core/frontend/src/components/logs/LogManager.vue
@@ -40,6 +40,9 @@
           :sort-by.sync="sortBy"
           :sort-desc.sync="sortDesc"
         >
+          <template #item.size="{ item }">
+            {{ printSize(item.size) }}
+          </template>
           <template #item.actions="{ item }">
             <v-icon @click="replay_log(item)">
               mdi-play
@@ -66,6 +69,7 @@ import Vue from 'vue'
 
 import filebrowser from '@/libs/filebrowser'
 import { FilebrowserFile } from '@/types/filebrowser'
+import { prettifySize } from '@/utils/helper_functions'
 
 import SpinningLogo from '../common/SpinningLogo.vue'
 
@@ -88,7 +92,7 @@ export default Vue.extend({
           sortable: false,
           value: 'name',
         },
-        { text: 'Size (MB)', value: 'size' },
+        { text: 'Size', value: 'size' },
         { text: 'Type', value: 'extension' },
         { text: 'Modified', value: 'modified' },
         {
@@ -108,7 +112,6 @@ export default Vue.extend({
       return this.available_logs.map((log) => ({
         ...log,
         modified: format(new Date(log.modified), 'yyyy-MM-dd HH:mm:ss'),
-        size: log.size / 1e6,
       }))
     },
   },
@@ -143,6 +146,9 @@ export default Vue.extend({
     },
     downloadLogs(logs: FilebrowserFile[]): void {
       filebrowser.downloadFiles(logs)
+    },
+    printSize(size_bytes: number): string {
+      return prettifySize(size_bytes / 1024)
     },
     async removeLogs(): Promise<void> {
       if (this.selected_logs.isEmpty()) return


### PR DESCRIPTION
LogManager shows the wrong size and size only in MB, making it less friendly for the user.
Old LogManager:
![2022-12-16_11-30](https://user-images.githubusercontent.com/1215497/208122931-07994298-9b8e-4ccf-b8d1-4b5d32c50b9f.png)

Size information on file-browser:
![2022-12-16_11-31](https://user-images.githubusercontent.com/1215497/208122983-b24bcc05-558a-4b3c-9a60-783588942aaa.png)


New LogManager:
![image](https://user-images.githubusercontent.com/1215497/208123026-62516c58-f984-4cdc-a3a0-0310f43f7961.png)



Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>