### PR TITLE
core: frontend: tweak extensions readme css

### DIFF
--- a/core/frontend/src/components/kraken/ExtensionModal.vue
+++ b/core/frontend/src/components/kraken/ExtensionModal.vue
@@ -198,3 +198,32 @@ export default Vue.extend({
   },
 })
 </script>
+<style>
+div.readme {
+  line-height: 200%;
+}
+div.readme p {
+  margin-top: 10px;
+  margin-left: 20px;
+}
+div.readme pre {
+  margin-left: 20px;
+}
+div.readme h1 {
+  margin-bottom: 20px;
+}
+
+div.readme h2 {
+  margin-bottom: 10px;
+  margin-left: 10px;
+}
+
+div.readme h3 {
+  margin-bottom: 10px;
+  margin-left: 20px;
+}
+
+div.readme ul {
+  margin-left: 20px;
+}
+</style>

--- a/core/frontend/src/views/ExtensionManagerView.vue
+++ b/core/frontend/src/views/ExtensionManagerView.vue
@@ -512,10 +512,6 @@ export default Vue.extend({
   padding: 0px !important;
 }
 
-div.readme h1 {
-  margin: 5px;
-}
-
 pre.logs {
   color:white;
   background: black;


### PR DESCRIPTION
Just trying to make things look a bit better:

before:
<img width="1101" alt="Screenshot 2022-12-16 at 15 30 22" src="https://user-images.githubusercontent.com/4013804/208165215-8f5251f0-f468-41ec-916a-7545e1ed8f42.png">


after:
<img width="1116" alt="Screenshot 2022-12-16 at 15 29 37" src="https://user-images.githubusercontent.com/4013804/208165134-73f9d939-6447-4516-a95d-cd54879017b9.png">
