### PR TITLE
core: tools: mavlink2rest: Update mavlink2rest to 0.11.10

### DIFF
--- a/core/tools/mavlink2rest/bootstrap.sh
+++ b/core/tools/mavlink2rest/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink2rest"
 
-VERSION=t0.11.7
+VERSION=t0.11.10
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/patrickelectric/mavlink2rest/releases/download/${VERSION}/mavlink2rest-armv7-unknown-linux-musleabihf"


### PR DESCRIPTION
New:
https://github.com/patrickelectric/mavlink2rest/releases/tag/t0.11.8
https://github.com/patrickelectric/mavlink2rest/releases/tag/t0.11.9
https://github.com/patrickelectric/mavlink2rest/releases/tag/t0.11.10

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>