### PR TITLE
core: frontend: ParameterEditor: Sort only by name

### DIFF
--- a/core/frontend/src/components/parameter-editor/ParameterEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditor.vue
@@ -15,6 +15,7 @@
       class="elevation-1"
       :search="search"
       :sort-by="'name'"
+      disable-sort="true"
       :custom-filter="() => true"
       @click:row="(value) => editParam(value.item)"
     >


### PR DESCRIPTION
There is no need to allow different sorts, and the work to do it do not worth

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>