### PR TITLE
core: frontend: SystemInformationView: Move 'System Monitor' to second page

### DIFF
--- a/core/frontend/src/views/SystemInformationView.vue
+++ b/core/frontend/src/views/SystemInformationView.vue
@@ -62,8 +62,8 @@ export default Vue.extend({
     return {
       settings,
       items: [
-        { title: 'Processes', icon: 'mdi-view-dashboard', value: 'process' },
         { title: 'System Monitor', icon: 'mdi-speedometer', value: 'system_condition' },
+        { title: 'Processes', icon: 'mdi-view-dashboard', value: 'process' },
         { title: 'Network', icon: 'mdi-ip-network-outline', value: 'network' },
         {
           title: 'Kernel', icon: 'mdi-text-long', value: 'kernel', is_pirate: true,


### PR DESCRIPTION

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>