### PR TITLE
core: frontend: NMEASocketCreationDialog: Add information about mavlink component

### DIFF
--- a/core/frontend/src/components/nmea-injector/NMEASocketCreationDialog.vue
+++ b/core/frontend/src/components/nmea-injector/NMEASocketCreationDialog.vue
@@ -33,6 +33,8 @@
             :counter="3"
             label="Mavlink component ID"
             :rules="[validate_required_field, is_component_id]"
+            :append-icon="'mdi-information-outline'"
+            @click:append="openMavlinkComponentIDInfo"
           />
 
           <v-btn
@@ -138,6 +140,9 @@ export default Vue.extend({
           notifier.pushBackError('NMEA_SOCKET_CREATE_FAIL', error)
         })
       return true
+    },
+    openMavlinkComponentIDInfo(): void {
+      window.open('https://mavlink.io/en/messages/common.html#MAV_COMPONENT', '_blank')
     },
     showDialog(state: boolean) {
       this.$emit('change', state)


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1215497/212776716-d9928d0f-75ec-4656-9f2b-43bb9fcde8c5.png)


Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>