### PR TITLE
Add suport for OCI manifests

### DIFF
--- a/core/services/versionchooser/utils/dockerhub.py
+++ b/core/services/versionchooser/utils/dockerhub.py
@@ -70,7 +70,7 @@ class TagFetcher:
         """Fetches the digest sha from a tag. This returns the image id displayed by 'docker image ls'"""
         header = {
             "Authorization": f"Bearer {self.last_token}",
-            "Accept": "application/vnd.docker.distribution.manifest.v2+json",
+            "Accept": "application/vnd.docker.distribution.manifest.v2+json,application/vnd.oci.image.manifest.v1+json",
         }
         async with aiohttp.ClientSession() as session:
             url = f"{self.index_url}/v2/{metadata.repository}/manifests/{metadata.digest}"


### PR DESCRIPTION
We were getting `OCI manifest found, but accept header does not support OCI (Open Container Initiative) manifest` errors when trying to fetch latest master manifests. My guess is that we somehow are shipping the image (or at least the manifest) in a different container format now:
<img width="985" alt="Screenshot 2023-01-22 at 14 06 10" src="https://user-images.githubusercontent.com/4013804/213929557-25fdb477-2019-464f-9ed9-5d67e5de2c98.png">


The error message doesn't look particularly good. but I'm happy to have the additional data in there

fix #1368 
fix #1379

potentially replaces #1384 

tested both in an older master with local changes, and current master with local changes. it seems to work fine:

<img width="881" alt="Screenshot 2023-01-22 at 14 09 19" src="https://user-images.githubusercontent.com/4013804/213929613-4a5becaa-5fe0-46ad-aed2-d1976e2534e9.png">

solution was grabbed from https://gitlab.com/gitlab-org/gitlab-foss/-/merge_requests/31127