### PR TITLE
core: frontend: autopilot: parameters: Add  to Array<Parameter>

### DIFF
--- a/core/frontend/src/types/autopilot/parameter.ts
+++ b/core/frontend/src/types/autopilot/parameter.ts
@@ -38,3 +38,21 @@ export default interface Parameter {
 
     units?: string
 }
+
+export declare interface Array<T = Parameter> {
+    get(this: Parameter[], matcher: string | object): Parameter[] | undefined;
+}
+
+// eslint-disable-next-line
+Object.defineProperty(Array.prototype, 'get', {
+  // eslint-disable-next-line
+  value: function(this: Parameter[], matcher: string | object): Parameter[] | undefined {
+    let tester: RegExp
+    if (typeof matcher === 'string') {
+      tester = new RegExp(matcher)
+    } else {
+      tester = matcher as RegExp
+    }
+    return this.filter((param: Parameter) => tester.test(param.name))
+  },
+})


### PR DESCRIPTION
Allow the usage of:

`parameters.get("SERVO(\d+)_FUNCTION")`

it'll return a list of available parameters if it exists