### PR TITLE
core: tools: mavlink-camera-manager: Update to t3.10.1.

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink-camera-manager"
 ARTIFACT_PREFIX="mavlink-camera-manager"
-VERSION=t3.10.0
+VERSION=t3.10.1
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/bluerobotics/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-armv7.zip"


### PR DESCRIPTION
This minor version update fixes both the freezing streams when starting WebRTC streams, and the freezing WebRTC stream when we add more clients to the same stream. 

[Change log here](https://github.com/bluerobotics/mavlink-camera-manager/releases/tag/t3.10.1)