### PR TITLE
core: frontend: health: HealthTrayMenu: Break out icons to allow custom menus

### DIFF
--- a/core/frontend/src/components/health/HealthTrayMenu.vue
+++ b/core/frontend/src/components/health/HealthTrayMenu.vue
@@ -1,93 +1,136 @@
 <template>
-  <v-menu
-    :close-on-content-click="false"
-    nudge-left="150"
-    nudge-bottom="25"
-  >
-    <template
-      #activator="{ on, attrs }"
+  <v-row style="display: contents;">
+    <v-menu
+      :close-on-content-click="false"
+      nudge-left="150"
+      nudge-bottom="25"
     >
-      <v-card
-        elevation="0"
-        color="transparent"
-        v-bind="attrs"
-        v-on="on"
+      <template
+        #activator="{ on, attrs }"
       >
-        <v-icon
-          v-if="disk_usage_high"
-          class="px-1 blinking white-shadow"
-          color="red"
-          :title="`High disk usage high! (${disk_usage_percent.toFixed(1)}%) please clean up the disk`"
+        <v-card
+          elevation="0"
+          color="transparent"
+          v-bind="attrs"
+          v-on="on"
         >
-          mdi-content-save-alert
-        </v-icon>
-        <v-icon
-          v-if="cpu_temperature_limit_reached"
-          class="px-1 blinking white-shadow"
-          color="error"
-          :title="`CPU temperature too high (${cpu_temperature} ºC), please cool down your vehicle!`"
-        >
-          mdi-thermometer
-        </v-icon>
-        <v-icon
-          v-if="cpu_throttled"
-          class="px-1 blinking white-shadow"
-          color="error"
-          :title="`CPU is throttled. Performance may be affected. Please check your power supply and cooling!`"
-        >
-          mdi-gauge-empty
-        </v-icon>
-        <v-icon
-          v-if="cpu_undervoltage"
-          class="px-1 blinking white-shadow"
-          color="error"
-          :title="`CPU has reported low voltage. Please check your power supply!`"
-        >
-          mdi-lightning-bolt
-        </v-icon>
-        <v-icon
-          v-if="heartbeat_age() < time_limit_heartbeat"
-          class="px-1"
-          :color="`rgba(255,255,255,${0.4 + (1000-heartbeat_age())/1000}`"
-          title="MAVLink heartbeats arriving as expected"
-        >
-          mdi-heart-pulse
-        </v-icon>
-        <v-icon
-          v-if="heartbeat_age() >= time_limit_heartbeat"
-          class="px-1 white-shadow"
-          color="error"
-          title="MAVLink heartbeat lost"
-        >
-          mdi-heart-broken
-        </v-icon>
-      </v-card>
-    </template>
+          <v-icon
+            v-if="disk_usage_high"
+            class="px-1 blinking white-shadow"
+            color="red"
+            :title="`High disk usage high! (${disk_usage_percent.toFixed(1)}%) please clean up the disk`"
+          >
+            mdi-content-save-alert
+          </v-icon>
+        </v-card>
+      </template>
 
-    <v-card
-      elevation="1"
-      width="250"
+      <v-card
+        elevation="1"
+        width="350"
+      >
+        <v-container>
+          <div>
+            <table style="width: 100%">
+              <tr>
+                <td>Percentage (Full):</td>
+                <td>{{ disk_usage_percent.toFixed(1) }} %</td>
+              </tr>
+              <tr>
+                <td>Free:</td>
+                <td> {{ disk_free_friendly }}</td>
+              </tr>
+              <tr>
+                <td>Total:</td>
+                <td> {{ disk_size_friendly }}</td>
+              </tr>
+            </table>
+          </div>
+        </v-container>
+      </v-card>
+    </v-menu>
+    <v-icon
+      v-if="cpu_temperature_limit_reached"
+      class="px-1 blinking white-shadow"
+      color="error"
+      :title="`CPU temperature too high (${cpu_temperature} ºC), please cool down your vehicle!`"
     >
-      <v-container>
-        <div>
-          <table style="width: 100%">
-            <tr>
-              <td>Core Temperature:</td>
-              <td>{{ cpu_temperature }} ºC</td>
-            </tr>
-            <tr>
-              <td>Voltage:</td>
-              <td>{{ battery_voltage }} V</td>
-            </tr>
-            <tr>
-              <td>Current:</td>
-              <td> {{ battery_current }} A</td>
-            </tr>
-          </table>
-        </div>
-      </v-container>
-    </v-card>
-  </v-menu>
+      mdi-thermometer
+    </v-icon>
+    <v-icon
+      v-if="cpu_throttled"
+      class="px-1 blinking white-shadow"
+      color="error"
+      :title="`CPU is throttled. Performance may be affected. Please check your power supply and cooling!`"
+    >
+      mdi-gauge-empty
+    </v-icon>
+    <v-icon
+      v-if="cpu_undervoltage"
+      class="px-1 blinking white-shadow"
+      color="error"
+      :title="`CPU has reported low voltage. Please check your power supply!`"
+    >
+      mdi-lightning-bolt
+    </v-icon>
+    <v-menu
+      :close-on-content-click="false"
+      nudge-left="150"
+      nudge-bottom="25"
+    >
+      <template
+        #activator="{ on, attrs }"
+      >
+        <v-card
+          elevation="0"
+          color="transparent"
+          v-bind="attrs"
+          v-on="on"
+        >
+          <v-icon
+            v-if="heartbeat_age() < time_limit_heartbeat"
+            class="px-1"
+            :color="`rgba(255,255,255,${0.4 + (1000-heartbeat_age())/1000}`"
+            title="MAVLink heartbeats arriving as expected"
+          >
+            mdi-heart-pulse
+          </v-icon>
+          <v-icon
+            v-if="heartbeat_age() >= time_limit_heartbeat"
+            class="px-1 white-shadow"
+            color="error"
+            title="MAVLink heartbeat lost"
+          >
+            mdi-heart-broken
+          </v-icon>
+        </v-card>
+      </template>
+
+      <v-card
+        elevation="1"
+        width="250"
+      >
+        <v-container>
+          <div>
+            <table style="width: 100%">
+              <tr>
+                <td>Core Temperature:</td>
+                <td>{{ cpu_temperature }} ºC</td>
+              </tr>
+              <tr>
+                <td>Voltage:</td>
+                <td>{{ battery_voltage }} V</td>
+              </tr>
+              <tr>
+                <td>Current:</td>
+                <td> {{ battery_current }} A</td>
+              </tr>
+            </table>
+          </div>
+        </v-container>
+      </v-card>
+    </v-menu>
+  </v-row>
 </template>
 
 <script lang="ts">
@@ -97,6 +140,7 @@ import mavlink2rest from '@/libs/MAVLink2Rest'
 import mavlink from '@/store/mavlink'
 import system_information from '@/store/system-information'
 import { RaspberryEventType } from '@/types/system-information/platform'
+import { Disk } from '@/types/system-information/system'
 import mavlink_store_get from '@/utils/mavlink'
 
 export default Vue.extend({
@@ -140,10 +184,20 @@ export default Vue.extend({
       const current_centiampere = mavlink_store_get(mavlink, 'SYS_STATUS.messageData.message.current_battery') as number
       return (current_centiampere as number / 100).toFixed(2)
     },
-    disk_usage_percent(): number {
+    main_disk(): undefined | Disk {
       const disks = system_information.system?.disk
-      const main_disk = disks?.find((sensor) => sensor.mount_point === '/')
-      return main_disk ? 100 - main_disk.available_space_B / main_disk.total_space_B / 0.01 : 0
+      return disks?.find((sensor) => sensor.mount_point === '/')
+    },
+    disk_usage_percent(): number {
+      return this.main_disk ? 100 - this.main_disk.available_space_B / this.main_disk.total_space_B / 0.01 : 0
+    },
+    disk_size_friendly(): string {
+      const total_GB = (this.main_disk?.total_space_B ?? 0) / 2 ** 30
+      return `${total_GB.toFixed(3)} GB`
+    },
+    disk_free_friendly(): string {
+      const free_GB = (this.main_disk?.available_space_B ?? 0) / 2 ** 30
+      return `${free_GB.toFixed(3)} GB`
     },
     disk_usage_high(): boolean {
       return this.disk_usage_percent > 85


### PR DESCRIPTION
Now its possible to click in individual icons to have specific information

![image](https://user-images.githubusercontent.com/1215497/215265685-eb0a8d93-d5b5-46d4-92f5-fb217180e1b3.png)


Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>