### PR TITLE
create "userdata" folder for allowing customizations

### DIFF
--- a/bootstrap/startup.json.default
+++ b/bootstrap/startup.json.default
@@ -29,6 +29,10 @@
             "/var/logs/blueos": {
                 "bind": "/var/logs/blueos",
                 "mode": "rw"
+            },
+            "/usr/blueos/userdata": {
+                "bind": "/usr/blueos/userdata",
+                "mode": "rw"
             }
         },
         "privileged": true

--- a/core/frontend/public/index.html
+++ b/core/frontend/public/index.html
@@ -6,6 +6,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
     <title><%= htmlWebpackPlugin.options.title %></title>
+    <link rel="stylesheet" href="/userdata/styles/theme_style.css">
   </head>
   <body>
     <noscript>

--- a/core/frontend/vue.config.js
+++ b/core/frontend/vue.config.js
@@ -72,6 +72,9 @@ module.exports = {
       '^/terminal': {
         target: SERVER_ADDRESS,
       },
+      '^/userdata': {
+        target: SERVER_ADDRESS,
+      },
       '^/version-chooser': {
         target: SERVER_ADDRESS,
         selfHandleResponse: true,

--- a/core/tools/blueos_startup_update/blueos_startup_update
+++ b/core/tools/blueos_startup_update/blueos_startup_update
@@ -21,6 +21,10 @@ DELTA_JSON = {
             '/etc/dhcpcd.conf': {
                 'bind': '/etc/dhcpcd.conf',
                 'mode': 'rw'
+            },
+            "/usr/blueos/userdata": {
+                "bind": "/usr/blueos/userdata",
+                "mode": "rw"
             }
         }
     }

--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -187,6 +187,15 @@ http {
             try_files $uri $uri/ /index.html;
         }
 
+        location /userdata {
+            root /usr/blueos;
+            autoindex on;
+            # disable cache to improve developer experience
+            # this should have very little impact for users
+            expires -1;
+            add_header Cache-Control no-store;
+        }
+
         location ~* \.html$ {
             root /home/pi/frontend;
             try_files $uri $uri/ /index.html;


### PR DESCRIPTION
Currently works with custom css files located in the host's [/home/pi/userdata/](http://blueos.local:7777/file-browser/files/home/pi/userdata/)user_style.css`
![image](https://user-images.githubusercontent.com/4013804/215818706-2e7a3064-4b24-452c-b165-22396ce5a4e5.png)

The screenshot uses these updated variables:
```
:root {
    --v-primary-base: #dd8603 !important;
    --v-info-base: #dd8603 !important;
    }
```
The full list  (courtesy of somewhere in chrome's dev tools) is here:  (upload when chrome is happier)

I intend to use the same or a similar mechanism to allow overriding images/models.