### PR TITLE
core: frontend: videoOverview: fix inverted logic of has_supported_encode()

### DIFF
--- a/core/frontend/src/components/vehiclesetup/overview/VideoOverview.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/VideoOverview.vue
@@ -63,7 +63,7 @@ export default Vue.extend({
 
     devices() {
       function has_supported_encode(device: Device): boolean {
-        return !device.formats.some((format: Format) => format.encode === VideoEncodeType.H264)
+        return device.formats.some((format: Format) => format.encode === VideoEncodeType.H264)
       }
       const devices = video.available_devices
       const valid_devices = devices.filter(


### PR DESCRIPTION
oops