### PR TITLE
Move away from node 12

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Set up Python ${{ env.python-version }}
       uses: actions/setup-python@v2
@@ -67,7 +67,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           submodules: recursive
 
@@ -98,7 +98,7 @@ jobs:
         platforms: ["linux/arm/v7"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0 #Number of commits to fetch. 0 indicates all history for all branches and tags.
           submodules: recursive

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -72,17 +72,17 @@ jobs:
           submodules: recursive
 
       - name: Yarn install
-        uses: borales/actions-yarn@v3.0.0
+        uses: borales/actions-yarn@v4
         with:
           cmd: --cwd ./core/frontend install --frozen-lockfile --ignore-engines
 
       - name: Yarn lint
-        uses: borales/actions-yarn@v3.0.0
+        uses: borales/actions-yarn@v4
         with:
           cmd: --cwd ./core/frontend lint --ignore-engines --max-warnings=36
 
       - name: Yarn build
-        uses: borales/actions-yarn@v3.0.0
+        uses: borales/actions-yarn@v4
         with:
           cmd: --cwd ./core/frontend build --ignore-engines
 

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -57,7 +57,7 @@ jobs:
         ./.hooks/pre-push
 
     - name: Upload coverage
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: coverage
         path: htmlcov
@@ -205,7 +205,7 @@ jobs:
             --output "type=docker,dest=BlueOs-core-${GIT_HASH_SHORT}.tar" \
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         if: success() && matrix.docker == 'core'
         with:
           name: BlueOS-core-docker-image.zip
@@ -256,7 +256,7 @@ jobs:
           zip BlueOS-raspberry.zip deploy/pimod/blueos.img
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           # We use the .img to avoid a zip of a zip
           name: BlueOS-raspberry.zip

--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -23,7 +23,7 @@ jobs:
       uses: actions/checkout@v3
 
     - name: Set up Python ${{ env.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ env.python-version }}
 


### PR DESCRIPTION
The current version uses Node 12 that's deprecated. Ref: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/

Signed-off-by: Patrick José Pereira <patrickelectric@gmail.com>