### PR TITLE
core: create filesystem shortcutes/symlinks

### DIFF
--- a/core/Dockerfile
+++ b/core/Dockerfile
@@ -64,5 +64,13 @@ RUN [ -z "$GIT_DESCRIBE_TAGS" ] \
 RUN RCFILE_PATH="/etc/blueosrc" \
     && echo "export GIT_DESCRIBE_TAGS=$GIT_DESCRIBE_TAGS" >> $RCFILE_PATH
 
+# create some Symlinks to make life easier
+RUN mkdir /shortcuts
+RUN ln -s /root/.config /shortcuts/configs
+RUN ln -s /var/logs/blueos/services /shortcuts/system_logs
+RUN ln -s /usr/blueos/userdata /shortcuts/userdata
+RUN ln -s /root/.config/ardupilot-manager /shortcuts/ardupilot_logs
+RUN ln -s / /shortcuts/system_root
+
 # Start
 CMD /bin/bash -i /usr/bin/start-blueos-core && sleep infinity

--- a/core/tools/filebrowser/bootstrap.sh
+++ b/core/tools/filebrowser/bootstrap.sh
@@ -18,5 +18,5 @@ chmod +x "$LOCAL_BINARY_PATH"
 # Create configuration file
 DATABASE_PATH="/etc/filebrowser/filebrowser.db"
 mkdir -p $(dirname "$DATABASE_PATH")
-filebrowser config init --address=0.0.0.0 --port=7777 --auth.method=noauth --log=stdout --root=/ --database="$DATABASE_PATH"
+filebrowser config init --address=0.0.0.0 --port=7777 --auth.method=noauth --log=stdout --root=/shortcuts --database="$DATABASE_PATH"
 filebrowser users add pi raspberry --database="$DATABASE_PATH"


### PR DESCRIPTION
Have you ever had to tell users where to find some specific data in the filesystem?
Worry no more! With the new, revamped "shortcuts 2000", your path-finding days are over!

We now offer a revolutionary way of directing users to the correct folders:

<img width="638" alt="Screenshot 2023-02-09 at 13 40 51" src="https://user-images.githubusercontent.com/4013804/217879972-26072c9d-55cc-4418-8c2f-cac5820b7c18.png">

And that is not all.  If you review it in the next 2 hours, you get it for absolutely FREE! that's right, "free" as in "free beer" AND "free" as in "freedom" !!!!11!!eleven!!

image at williangalvani/blueos-core:shortcutes