### PR TITLE
Dialog parameter

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -24,6 +24,7 @@
         <beacon-tray-menu />
         <health-tray-menu />
         <theme-tray-menu />
+        <vehicle-reboot-required-tray-menu />
         <pirate-mode-tray-menu />
         <wifi-tray-menu />
         <ethernet-tray-menu />
@@ -223,6 +224,7 @@ import PowerMenu from './components/app/PowerMenu.vue'
 import ReportMenu from './components/app/ReportMenu.vue'
 import SettingsMenu from './components/app/SettingsMenu.vue'
 import ThemeTrayMenu from './components/app/ThemeTrayMenu.vue'
+import VehicleRebootRequiredTrayMenu from './components/app/VehicleRebootRequiredTrayMenu.vue'
 import BeaconTrayMenu from './components/beacon/BeaconTrayMenu.vue'
 import EthernetTrayMenu from './components/ethernet/EthernetTrayMenu.vue'
 import EthernetUpdater from './components/ethernet/EthernetUpdater.vue'
@@ -271,6 +273,7 @@ export default Vue.extend({
     'backend-status-checker': BackendStatusChecker,
     Alerter,
     'new-version-notificator': NewVersionNotificator,
+    VehicleRebootRequiredTrayMenu,
   },
 
   data: () => ({

--- a/core/frontend/src/components/app/VehicleRebootMenu.vue
+++ b/core/frontend/src/components/app/VehicleRebootMenu.vue
@@ -1,0 +1,55 @@
+<template>
+  <v-card
+    class="d-flex flex-column align-center pa-3"
+    outlined
+    width="350"
+  >
+    <v-alert
+      type="info"
+      icon="mdi-skull-crossbones"
+      elevation="1"
+      text
+    >
+      Autopilot reboot is necessary for new settings to take effect.
+    </v-alert>
+    <v-btn
+      @click="rebootVehicle"
+    >
+      Reboot Autopilot
+    </v-btn>
+  </v-card>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+import Notifier from '@/libs/notifier'
+import autopilot_data from '@/store/autopilot'
+import autopilot from '@/store/autopilot_manager'
+import { parameters_service } from '@/types/frontend_services'
+import back_axios from '@/utils/api'
+
+const notifier = new Notifier(parameters_service)
+
+export default Vue.extend({
+  name: 'VehicleRebootMenu',
+  methods: {
+    async rebootVehicle(): Promise<void> {
+      autopilot_data.reset()
+      autopilot.setRestarting(true)
+      await back_axios({
+        method: 'post',
+        url: `${autopilot.API_URL}/restart`,
+        timeout: 10000,
+      })
+        .catch((error) => {
+          notifier.pushBackError('AUTOPILOT_RESTART_FAIL', error)
+        })
+        .finally(() => {
+          autopilot.setRestarting(false)
+          autopilot_data.setRebootRequired(false)
+        })
+    },
+  },
+})
+</script>

--- a/core/frontend/src/components/app/VehicleRebootRequiredTrayMenu.vue
+++ b/core/frontend/src/components/app/VehicleRebootRequiredTrayMenu.vue
@@ -1,0 +1,75 @@
+<template>
+  <v-menu
+    v-if="autopilot_data.reboot_required"
+    v-model="show_menu"
+    :close-on-content-click="false"
+    nudge-left="200"
+    nudge-bottom="25"
+  >
+    <template
+      #activator="{ on, attrs }"
+    >
+      <v-card
+        id="pirate-mode-tray-menu-button"
+        class="px-1"
+        elevation="0"
+        color="transparent"
+        v-bind="attrs"
+        v-on="on"
+      >
+        <v-icon
+          class="blinking"
+        >
+          mdi-restart-alert
+        </v-icon>
+      </v-card>
+    </template>
+    <vehicle-reboot-menu
+      @vehicleRebootCalled="showMenu(false)"
+    />
+  </v-menu>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+import autopilot_data from '@/store/autopilot'
+
+import VehicleRebootMenu from './VehicleRebootMenu.vue'
+
+export default Vue.extend({
+  name: 'VehicleRebootRequiredTrayMenu',
+  components: {
+    VehicleRebootMenu,
+  },
+  data: () => ({
+    autopilot_data,
+    show_menu: false,
+  }),
+  methods: {
+    showMenu(show: boolean): void {
+      this.show_menu = show
+    },
+  },
+})
+</script>
+
+<style scoped>
+  .blinking {
+    animation-name: blinking;
+    animation-duration: 2s;
+    animation-iteration-count: infinite;
+  }
+
+  @keyframes blinking {
+    100% {color: red;}
+    75% {color: yellow;}
+    50% {color: red;}
+    25% {color: yellow;}
+    0% {color: red;}
+  }
+
+  .white-shadow {
+    text-shadow: 0 0 3px #FFF;
+  }
+</style>

--- a/core/frontend/src/components/parameter-editor/ParameterEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditor.vue
@@ -88,125 +88,12 @@
           </v-icon>
           <div>Load</div>
         </v-btn>
-        <v-btn
-          v-if="need_vehicle_reboot"
-          v-tooltip="'A parameter that requires a vehicle reboot was changed'"
-          :disabled="!finished_loading"
-          color="warning"
-          class="mr-5"
-          @click="rebootVehicle()"
-        >
-          <div>Reboot vehicle</div>
-        </v-btn>
       </template>
     </v-data-table>
-    <v-dialog
+    <parameter-editor-dialog
       v-model="edit_dialog"
-      max-width="500px"
-    >
-      <v-card>
-        <v-card-title>
-          <span class="text-h5">{{ edited_param?.name ?? '' }}</span>
-        </v-card-title>
-
-        <v-card-text>
-          <v-container
-            v-if="edited_param"
-          >
-            <v-row v-if="edited_param.rebootRequired">
-              Reboot Required
-            </v-row>
-            <v-row>
-              {{ edited_param.description }}
-            </v-row>
-            <v-row
-              v-if="edited_param.range"
-              class="pt-6"
-            >
-              Min: {{ edited_param.range.low }}
-              Max: {{ edited_param.range.high }}
-              Increment: {{ edited_param.increment ?? 0.01 }}
-            </v-row>
-            <v-row>
-              <v-col
-                cols="6"
-                sm="6"
-                md="6"
-              >
-                <v-form
-                  ref="form"
-                >
-                  <template v-if="!custom_input && edited_param.bitmask">
-                    <v-checkbox
-                      v-for="(key, value) in edited_param?.bitmask"
-                      :key="value"
-                      v-model="edited_bitmask"
-                      dense
-                      :label="key"
-                      :value="2 ** value"
-                    />
-                  </template>
-                  <v-select
-                    v-else-if="!custom_input && edited_param?.options"
-                    v-model.number="new_value"
-                    :items="as_select_tems"
-                    :rules="[() => true]"
-                  />
-                  <v-text-field
-                    v-if="custom_input || (edited_param && !edited_param.options && !edited_param.bitmask)"
-                    v-model.number="new_value"
-                    label="Value"
-                    type="number"
-                    :step="edited_param.increment ?? 0.01"
-                    :suffix="edited_param.units"
-                    :rules="forcing_input ? [] : [isInRange, isValidType]"
-                  />
-
-                  <v-checkbox
-                    v-if="show_advanced_checkbox"
-                    v-model="forcing_input"
-                    dense
-                    :label="'Force'"
-                  />
-                  <v-checkbox
-                    v-if="show_custom_checkbox"
-                    v-model="custom_input"
-                    dense
-                    :label="'Custom'"
-                  />
-                </v-form>
-              </v-col>
-            </v-row>
-          </v-container>
-        </v-card-text>
-
-        <v-card-actions>
-          <v-spacer />
-          <v-btn
-            color="primary"
-            @click="edit_dialog = false"
-          >
-            Cancel
-          </v-btn>
-          <v-btn
-            :disabled="paramValueNotChanged"
-            color="primary"
-            @click="saveEditedParam()"
-          >
-            Save
-          </v-btn>
-          <v-btn
-            v-if="edited_param?.rebootRequired === true"
-            v-tooltip="'Reboot required for parameter to take effect'"
-            :disabled="paramValueNotChanged"
-            color="warning"
-            @click="saveEditedParam(true)"
-          >
-            Save and Reboot
-          </v-btn>
-        </v-card-actions>
-      </v-card>
-    </v-dialog>
+      :param="edited_param"
+    />
     <v-dialog
       v-model="load_param_dialog"
       max-width="500px"
@@ -265,30 +152,24 @@ import Fuse from 'fuse.js'
 import Vue from 'vue'
 
 import mavlink2rest from '@/libs/MAVLink2Rest'
-import Notifier from '@/libs/notifier'
 import autopilot_data from '@/store/autopilot'
 import autopilot from '@/store/autopilot_manager'
 import Parameter, { ParamType, printParam } from '@/types/autopilot/parameter'
-import { parameters_service } from '@/types/frontend_services'
-import { VForm } from '@/types/vuetify'
-import back_axios from '@/utils/api'
 
-const notifier = new Notifier(parameters_service)
+import ParameterEditorDialog from './ParameterEditorDialog.vue'
 
 export default Vue.extend({
   name: 'ParameterEditor',
+  components: {
+    ParameterEditorDialog,
+  },
   data() {
     return {
       search: '',
       edited_param: undefined as (undefined | Parameter),
       edit_dialog: false,
-      edited_bitmask: [] as number[],
-      forcing_input: false,
       load_param_dialog: false,
       loaded_parameter: [] as {name: string, value: number, type: undefined | ParamType}[],
-      custom_input: false,
-      new_value: 0,
-      need_vehicle_reboot: false,
     }
   },
   computed: {
@@ -329,153 +210,14 @@ export default Vue.extend({
     finished_loading() {
       return autopilot_data.finished_loading
     },
-    form(): VForm {
-      return this.$refs.form as VForm
-    },
-    show_advanced_checkbox(): boolean {
-      return typeof this.isInRange(this.new_value ?? 0) === 'string'
-    },
-    show_custom_checkbox(): boolean {
-      return !!(this.edited_param?.options || this.edited_param?.bitmask)
-    },
-    as_select_tems() {
-      const entries = Object.entries(this.edited_param?.options ?? [])
-      return entries.map(([value, name]) => ({ text: name, value: parseFloat(value), disabled: false }))
-    },
-    editedBitmaskValue(): number {
-      return this.edited_bitmask.reduce((accumulator, current) => accumulator + current, 0)
-    },
-    paramValueNotChanged(): boolean {
-      // Check if value is different
-      return this.new_value === this.edited_param?.value
-        // Check if bitmask value, if valid, is different from current value
-        && (this.edited_param?.bitmask === undefined || this.editedBitmaskValue === this.edited_param?.value)
-    },
-  },
-  watch: {
-    edit_dialog(): void {
-      if (!this.edit_dialog) {
-        this.forcing_input = false
-        this.custom_input = false
-      }
-
-      // Select force input if value is outside of range initially
-      this.forcing_input = typeof this.isInRange(this.new_value) === 'string'
-
-      // Select custom input if value is outside of possible options
-      this.custom_input = !Object.keys(this.edited_param?.options ?? [])
-        .map((value) => parseFloat(value))
-        .includes(this.new_value)
-    },
-    new_value(): void {
-      // Remove forcing_input once option is inside valid range
-      if (this.forcing_input && typeof this.isInRange(this.new_value) === 'boolean') {
-        this.forcing_input = false
-      }
-
-      // Remove custom once value is known
-      if (this.custom_input) {
-        this.custom_input = !Object.keys(this.edited_param?.options ?? [])
-          .map((value) => parseFloat(value))
-          .includes(this.new_value)
-      }
-    },
   },
   methods: {
-    isInRange(input: number | string): boolean | string {
-      // The input value is an empty string when the field is empty
-      if (typeof input === 'string' && input?.trim().length === 0) {
-        return 'This should be a number between min and max'
-      }
-
-      if (!this.edited_param?.range) {
-        return true
-      }
-      if (input > this.edited_param.range.high) {
-        return `Value should be smaller than ${this.edited_param.range.high}`
-      }
-      if (input < this.edited_param.range.low) {
-        return `Value should be greater than ${this.edited_param.range.low}`
-      }
-      return true
-    },
-    isValidType(input: number): boolean | string {
-      if (this.edited_param?.paramType.type.includes('UINT')) {
-        if (input < 0) {
-          return 'This parameter must be a positive Integer'
-        }
-      }
-      if (this.edited_param?.paramType.type.includes('INT')) {
-        if (!Number.isInteger(input)) {
-          return 'This parameter must be an Integer'
-        }
-      }
-      return true
-    },
     editParam(param: Parameter) {
       if (param.readonly) {
         return
       }
       this.edited_param = param
-      this.new_value = this.edited_param?.value ?? 0
       this.edit_dialog = true
-      this.edited_bitmask = []
-      if (param.bitmask === undefined) {
-        return
-      }
-      // eslint-disable-next-line no-bitwise
-      for (let v = 0; 1 << v < param.value; v += 1) {
-        // eslint-disable-next-line no-bitwise
-        const bitmask_value = 1 << v
-        // eslint-disable-next-line no-bitwise
-        if (bitmask_value & param.value) {
-          this.edited_bitmask.push(bitmask_value)
-        }
-      }
-    },
-    async saveEditedParam(reboot = false) {
-      if (!this.forcing_input && !this.form?.validate()) {
-        return
-      }
-      this.edit_dialog = false
-      if (this.edited_param == null) {
-        return
-      }
-      if (!this.custom_input && this.edited_param.bitmask !== undefined) {
-        this.new_value = this.editedBitmaskValue
-      }
-      let value = 0
-      if (typeof this.new_value === 'string') {
-        value = parseFloat(this.new_value)
-      } else {
-        value = this.new_value
-      }
-
-      mavlink2rest.setParam(this.edited_param.name, value, this.edited_param.paramType.type)
-
-      if (reboot) {
-        await this.rebootVehicle()
-      } else if (this.edited_param.rebootRequired) {
-        this.need_vehicle_reboot = true
-      }
-    },
-    async rebootVehicle(): Promise<void> {
-      await this.restart_autopilot()
-      autopilot_data.reset()
-    },
-    async restart_autopilot(): Promise<void> {
-      autopilot.setRestarting(true)
-      await back_axios({
-        method: 'post',
-        url: `${autopilot.API_URL}/restart`,
-        timeout: 10000,
-      })
-        .catch((error) => {
-          notifier.pushBackError('AUTOPILOT_RESTART_FAIL', error)
-        })
-        .finally(() => {
-          autopilot.setRestarting(false)
-        })
     },
     printMark(item: Fuse.FuseResult<Record<string, string>>, key: string): string {
       const name = item.item[key]

--- a/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
@@ -159,10 +159,8 @@ export default Vue.extend({
         return edited_bitmask
       }
 
-      // eslint-disable-next-line no-bitwise
-      for (let v = 0; 1 << v < this.param.value; v += 1) {
-        // eslint-disable-next-line no-bitwise
-        const bitmask_value = 1 << v
+      for (let v = 0; 2 ** v <= this.param.value; v += 1) {
+        const bitmask_value = 2 ** v
         // eslint-disable-next-line no-bitwise
         if (bitmask_value & this.param.value) {
           edited_bitmask.push(bitmask_value)

--- a/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
@@ -60,6 +60,7 @@
                   :step="param.increment ?? 0.01"
                   :suffix="param.units"
                   :rules="forcing_input ? [] : [isInRange, isValidType]"
+                  @blur="update_variables"
                 />
 
                 <v-checkbox
@@ -186,9 +187,6 @@ export default Vue.extend({
     },
   },
   watch: {
-    new_value(): void {
-      this.update_variables()
-    },
     show(): void {
       this.new_value = this.param.value
 

--- a/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
@@ -1,0 +1,310 @@
+<template>
+  <v-dialog
+    max-width="500px"
+    :value="show"
+    @input="showDialog"
+  >
+    <v-card>
+      <v-card-title>
+        <span class="text-h5">{{ param?.name ?? "" }}</span>
+      </v-card-title>
+
+      <v-card-text>
+        <v-container v-if="param">
+          <v-row v-if="param.rebootRequired"> Reboot Required </v-row>
+          <v-row>
+            {{ param.description }}
+          </v-row>
+          <v-row
+            v-if="param.range"
+            class="pt-6"
+          >
+            Min: {{ param.range.low }} Max:
+            {{ param.range.high }} Increment:
+            {{ param.increment ?? 0.01 }}
+          </v-row>
+          <v-row>
+            <v-col
+              cols="6"
+              sm="6"
+              md="6"
+            >
+              <v-form ref="form">
+                <template v-if="!custom_input && param.bitmask">
+                  <v-checkbox
+                    v-for="(key, value) in param?.bitmask"
+                    :key="value"
+                    v-model="edited_bitmask"
+                    dense
+                    :label="key"
+                    :value="2 ** value"
+                  />
+                </template>
+                <v-select
+                  v-else-if="!custom_input && param?.options"
+                  v-model.number="new_value"
+                  :items="as_select_tems"
+                  :rules="[() => true]"
+                />
+                <v-text-field
+                  v-if="
+                    custom_input ||
+                      (param
+                        && !param.options
+                        && !param.bitmask
+                      )
+                  "
+                  v-model.number="new_value"
+                  label="Value"
+                  type="number"
+                  :step="param.increment ?? 0.01"
+                  :suffix="param.units"
+                  :rules="forcing_input ? [] : [isInRange, isValidType]"
+                />
+
+                <v-checkbox
+                  v-if="show_advanced_checkbox"
+                  v-model="forcing_input"
+                  dense
+                  :label="'Force'"
+                />
+                <v-checkbox
+                  v-if="show_custom_checkbox"
+                  v-model="custom_input"
+                  dense
+                  :label="'Custom'"
+                />
+              </v-form>
+            </v-col>
+          </v-row>
+        </v-container>
+      </v-card-text>
+
+      <v-card-actions>
+        <v-spacer />
+        <v-btn
+          color="primary"
+          @click="showDialog(false)"
+        >
+          Cancel
+        </v-btn>
+        <v-btn
+          :disabled="param_value_not_changed || !is_form_valid"
+          color="primary"
+          @click="saveEditedParam()"
+        >
+          Save
+        </v-btn>
+        <v-btn
+          v-if="param?.rebootRequired === true"
+          v-tooltip="'Reboot required for parameter to take effect'"
+          :disabled="param_value_not_changed || !is_form_valid"
+          color="warning"
+          @click="saveEditedParam(true)"
+        >
+          Save and Reboot
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+<script lang="ts">
+import Vue, { PropType } from 'vue'
+
+import mavlink2rest from '@/libs/MAVLink2Rest'
+import Notifier from '@/libs/notifier'
+import autopilot_data from '@/store/autopilot'
+import autopilot from '@/store/autopilot_manager'
+import Parameter from '@/types/autopilot/parameter'
+import { parameters_service } from '@/types/frontend_services'
+import { VForm } from '@/types/vuetify'
+import back_axios from '@/utils/api'
+
+const notifier = new Notifier(parameters_service)
+
+export default Vue.extend({
+  name: 'ParameterEditorDialog',
+  model: {
+    prop: 'show',
+    event: 'change',
+  },
+  props: {
+    show: {
+      type: Boolean,
+      default: false,
+    },
+    param: {
+      type: Object as PropType<Parameter> | undefined,
+      default: undefined,
+    },
+  },
+  data() {
+    return {
+      custom_input: false,
+      forcing_input: false,
+      // Form can't be computed correctly, so we save it's state under data
+      is_form_valid: false,
+      new_value: 0,
+    }
+  },
+  computed: {
+    as_select_tems() {
+      const entries = Object.entries(this.param?.options ?? [])
+      return entries.map(([value, name]) => ({ text: name, value: parseFloat(value), disabled: false }))
+    },
+    edited_bitmask(): number[] {
+      const edited_bitmask = [] as number[]
+
+      if (this.param.readonly || this.param.bitmask === undefined) {
+        return edited_bitmask
+      }
+
+      // eslint-disable-next-line no-bitwise
+      for (let v = 0; 1 << v < this.param.value; v += 1) {
+        // eslint-disable-next-line no-bitwise
+        const bitmask_value = 1 << v
+        // eslint-disable-next-line no-bitwise
+        if (bitmask_value & this.param.value) {
+          edited_bitmask.push(bitmask_value)
+        }
+      }
+
+      return edited_bitmask
+    },
+    edited_bitmask_value(): number {
+      return this.edited_bitmask.reduce((accumulator, current) => accumulator + current, 0)
+    },
+    param_value_not_changed(): boolean {
+      // Check if value is different
+      return this.new_value === this.param?.value
+        // Check if bitmask value, if valid, is different from current value
+        && (this.param?.bitmask === undefined || this.edited_bitmask_value === this.param?.value)
+    },
+    show_advanced_checkbox(): boolean {
+      return typeof this.isInRange(this.new_value ?? 0) === 'string'
+    },
+    show_custom_checkbox(): boolean {
+      return !!(this.param?.options || this.param?.bitmask)
+    },
+  },
+  watch: {
+    new_value(): void {
+      this.update_variables()
+    },
+    show(): void {
+      this.new_value = this.param.value
+
+      if (!this.show) {
+        return
+      }
+
+      this.update_variables()
+    },
+  },
+  methods: {
+    isFormValid(): boolean {
+      const form = this.$refs.form as VForm
+      this.is_form_valid = form?.validate() === true
+      return this.is_form_valid
+    },
+    isInRange(input: number | string): boolean | string {
+      // The input value is an empty string when the field is empty
+      if (typeof input === 'string' && input?.trim().length === 0) {
+        return 'This should be a number between min and max'
+      }
+
+      if (!this.param?.range) {
+        return true
+      }
+      if (input > this.param.range.high) {
+        return `Value should be smaller than ${this.param.range.high}`
+      }
+      if (input < this.param.range.low) {
+        return `Value should be greater than ${this.param.range.low}`
+      }
+      return true
+    },
+    isValidType(input: number): boolean | string {
+      if (this.param?.paramType.type.includes('UINT')) {
+        if (input < 0) {
+          return 'This parameter must be a positive Integer'
+        }
+      }
+      if (this.param?.paramType.type.includes('INT')) {
+        if (!Number.isInteger(input)) {
+          return 'This parameter must be an Integer'
+        }
+      }
+      return true
+    },
+    async rebootVehicle(): Promise<void> {
+      await this.restart_autopilot()
+      autopilot_data.reset()
+    },
+    async restart_autopilot(): Promise<void> {
+      autopilot.setRestarting(true)
+      await back_axios({
+        method: 'post',
+        url: `${autopilot.API_URL}/restart`,
+        timeout: 10000,
+      })
+        .catch((error) => {
+          notifier.pushBackError('AUTOPILOT_RESTART_FAIL', error)
+        })
+        .finally(() => {
+          autopilot.setRestarting(false)
+        })
+    },
+    async saveEditedParam(reboot = false) {
+      if (!this.forcing_input && !this.isFormValid()) {
+        return
+      }
+      this.showDialog(false)
+      if (this.param == null) {
+        return
+      }
+      if (!this.custom_input && this.param.bitmask !== undefined) {
+        this.new_value = this.edited_bitmask_value
+      }
+      let value = 0
+      if (typeof this.new_value === 'string') {
+        value = parseFloat(this.new_value)
+      } else {
+        value = this.new_value
+      }
+
+      mavlink2rest.setParam(this.param.name, value, this.param.paramType.type)
+
+      if (reboot) {
+        await this.rebootVehicle()
+        autopilot_data.setRebootRequired(false)
+      } else if (this.param.rebootRequired) {
+        autopilot_data.setRebootRequired(true)
+      }
+    },
+    showDialog(state: boolean) {
+      this.$emit('change', state)
+    },
+    update_variables(): void {
+      // Remove forcing_input once option is inside valid range
+      if (this.forcing_input && typeof this.isInRange(this.new_value) === 'boolean') {
+        this.forcing_input = false
+      }
+
+      // Select custom input if value is outside of possible options
+      // Remove custom once value is known
+      if (this.custom_input) {
+        this.custom_input = !Object.keys(this.param?.options ?? [])
+          .map((value) => parseFloat(value))
+          .includes(this.new_value)
+      }
+
+      // Select force input if value is outside of range initially
+      this.forcing_input = typeof this.isInRange(this.new_value) === 'string'
+
+      // Update form validation
+      this.isFormValid()
+    },
+  },
+})
+</script>

--- a/core/frontend/src/store/autopilot.ts
+++ b/core/frontend/src/store/autopilot.ts
@@ -28,6 +28,8 @@ class AutopilotStore extends VuexModule {
 
   metadata_loaded = false
 
+  reboot_required = false
+
   get parameter() {
     return (name: string): Parameter | undefined => this.parameters.find((parameter) => parameter.name === name)
   }
@@ -70,6 +72,11 @@ class AutopilotStore extends VuexModule {
   setLoadedParametersCount(count: number): void {
     this.parameters_loaded = count
     this.finished_loading = this.parameters_loaded >= this.parameters_total && this.metadata_loaded
+  }
+
+  @Mutation
+  setRebootRequired(required: boolean): void {
+    this.reboot_required = required
   }
 
   @Mutation

--- a/core/frontend/src/types/autopilot/parameter.ts
+++ b/core/frontend/src/types/autopilot/parameter.ts
@@ -71,8 +71,7 @@ export function printParam(param?: Parameter): string {
     // We check up to 64 bits to make sure that we are going to cover all possible bits
     // Including the ones not listed in the bitmask
     for (let v = 0; v < 64; v += 1) {
-      // eslint-disable-next-line no-bitwise
-      const bitmask_value = 1 << v
+      const bitmask_value = 2 ** v
       // eslint-disable-next-line no-bitwise
       if (param.value & bitmask_value) {
         bitmask_result.push(param.bitmask?.[v] ?? `UNKNOWN (Bit ${v + 1})`)


### PR DESCRIPTION
Move parameter dialog to its own component to be used in different places.
Also turns the `autopilot reboot` button to be global, to follow the user between the pages until it's rebooted. 
![Peek 13-02-2023 18-45](https://user-images.githubusercontent.com/1215497/218581918-90c1a014-09d0-4ef5-ac69-4897edc87a97.gif)

Fix #1471

