### PR TITLE
Never go back

### DIFF
--- a/core/frontend/package.json
+++ b/core/frontend/package.json
@@ -39,7 +39,7 @@
     "marked": "^4.1.1",
     "register-service-worker": "^1.7.1",
     "roboto-fontface": "*",
-    "semver": "^7.3.5",
+    "semver": "^7.3.8",
     "semver-stable": "^3.0.0",
     "simple-icons": "^6.8.0",
     "util": "^0.12.5",

--- a/core/frontend/src/components/kraken/InstalledExtensionCard.vue
+++ b/core/frontend/src/components/kraken/InstalledExtensionCard.vue
@@ -145,6 +145,7 @@
 </template>
 
 <script lang="ts">
+import semver from 'semver'
 import stable from 'semver-stable'
 import Vue, { PropType } from 'vue'
 
@@ -200,6 +201,9 @@ export default Vue.extend({
     update_available() : false | string {
       const versions: string[] = Object.keys(this.extensionData?.versions ?? {})
       const lastest_stable = stable.max(versions)
+      if (semver.gt(this.extension.tag, lastest_stable)) {
+        return false
+      }
       return this.extension.tag === lastest_stable ? false : lastest_stable
     },
   },

--- a/core/frontend/yarn.lock
+++ b/core/frontend/yarn.lock
@@ -7737,7 +7737,7 @@ semver@^7.1.2, semver@^7.3.2, semver@^7.3.5:
   dependencies:
     lru-cache "^6.0.0"
 
-semver@^7.3.4, semver@^7.3.6, semver@^7.3.7:
+semver@^7.3.4, semver@^7.3.6, semver@^7.3.7, semver@^7.3.8:
   version "7.3.8"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.8.tgz#07a78feafb3f7b32347d725e33de7e2a2df67798"
   integrity sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==


### PR DESCRIPTION
Prevents the "Upgrade to xxx " button from showing to a lower version, in the case of the current one being pulled from the repo. (should we though?)