### PR TITLE
core: frontend: components: NetworkCard: Blur IPv6 adress

### DIFF
--- a/core/frontend/src/components/system-information/NetworkCard.vue
+++ b/core/frontend/src/components/system-information/NetworkCard.vue
@@ -22,6 +22,7 @@
         <v-col
           v-for="(ip, i) in network.ips"
           :key="i"
+          :style="ip.includes('::') ? 'cursor: pointer; filter:blur(0.5em)' : ''"
           class="pa-0 text-h6 text-center"
         >
           {{ ip }}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1215497/220113535-85d7fd4c-3f74-4eb3-a210-bf592ade6686.png)

IPv6 address should not be publicly available as mac