### PR TITLE
core: frontend: components: ParameterEditorDialog: Use v-autocomplete for big list of options

### DIFF
--- a/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
@@ -42,6 +42,12 @@
                     :value="2 ** value"
                   />
                 </template>
+                <v-autocomplete
+                  v-else-if="!custom_input && Object.entries(param?.options).length > 10"
+                  v-model.number="new_value"
+                  :items="as_select_tems"
+                  variant="solo"
+                />
                 <v-select
                   v-else-if="!custom_input && param?.options"
                   v-model.number="new_value"


### PR DESCRIPTION
Use autocomplete if the list of options is bigger than 10
![Peek 20-02-2023 14-14](https://user-images.githubusercontent.com/1215497/220167838-a6895bca-a73a-4760-907c-b89a5f117a2a.gif)

Fix #1495 