### PR TITLE
install: boards: bcm_27xx: Update firmware for raspbian

### DIFF
--- a/install/boards/bcm_27xx.sh
+++ b/install/boards/bcm_27xx.sh
@@ -77,7 +77,7 @@ grep -q cgroup $CMDLINE_FILE || (
 # Update raspberry pi firmware
 # this is required to avoid 'i2c transfer timed out' kernel errors
 # on older firmware versions
-if grep -q VERSION_CODENAME=buster < /etc/os-release; then
+if grep -q ID=raspbian < /etc/os-release; then
     RPI_FIRMWARE_VERSION=1340be4
     if sudo JUST_CHECK=1 rpi-update $RPI_FIRMWARE_VERSION | grep "Firmware update required"; then
         echo "- Run rpi update."


### PR DESCRIPTION
We are having USB problems with cameras where they stop working with the old firmware / bootloader / VL085 firmware