### PR TITLE
bootstrap: bootstrap: Revert to factory if getting NotFound error

### DIFF
--- a/bootstrap/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap/bootstrap.py
@@ -167,7 +167,7 @@ class Bootstrapper:
         if not self.image_is_available_locally(image_name, image_version):
             try:
                 self.pull(component_name)
-            except docker.errors.ImageNotFound:
+            except docker.errors.NotFound:
                 warn("Image not found, reverting to default...")
                 self.overwrite_config_file_with_defaults()
                 return False


### PR DESCRIPTION
From:
```
/bootstrap/bootstrap.py:175: UserWarning: Error trying to pull an upda
te image: 404 Client Error for http+docker://localhost/v1.42/images/create?tag=patrick_1.0.2&fromImage=bluerobotics%2Fblueos-core: Not Found ("manifest for blu
erobotics/blueos-core:patrick_1.0.2 not found: manifest unknown: manifest unknown")
  warn(f"Error trying to pull an update image: {error}")
```