### PR TITLE
core: frontend: autopilot: parameter: Use hexadecimal to show DEV_ID

### DIFF
--- a/core/frontend/src/types/autopilot/parameter.ts
+++ b/core/frontend/src/types/autopilot/parameter.ts
@@ -43,6 +43,12 @@ export function printParam(param?: Parameter): string {
   if (param === undefined) {
     return 'Unknown'
   }
+
+  // Show device id as an hexadecimal value
+  if (param?.name.includes('_DEV_ID') || param?.name.includes('_DEVID')) {
+    return `0x${param.value.toString(16).padStart(8, '0')}`
+  }
+
   // Check if there are options but zero does not cover it
   // Or if it's a bitmask, where no flags is 'None'
   const option_zero_does_not_exist = param.options !== undefined && param.options?.[0] === undefined


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/1215497/226670262-b45e5c8e-d799-418e-888d-c20fc7266dcc.png)

After:
![image](https://user-images.githubusercontent.com/1215497/226670185-be5ed357-71b8-4635-a0b1-4b799dda5ffc.png)
