### PR TITLE
core: frontend: SettingsMenu: Wait for log_folder_size longer

### DIFF
--- a/core/frontend/src/components/app/SettingsMenu.vue
+++ b/core/frontend/src/components/app/SettingsMenu.vue
@@ -119,7 +119,7 @@ export default Vue.extend({
       await back_axios({
         url: `${API_URL}/services/check_log_folder_size`,
         method: 'get',
-        timeout: 4000,
+        timeout: 30000,
       })
         .then((response) => {
           const folder_data_bytes = response.data


### PR DESCRIPTION
There is no reason to wait only 4 seconds, we can wait longer since the calculation time is based on the amount of files that exist. 