### PR TITLE
Allow using system ids other than 1

### DIFF
--- a/core/frontend/src/components/health/HealthTrayMenu.vue
+++ b/core/frontend/src/components/health/HealthTrayMenu.vue
@@ -137,6 +137,7 @@
 import Vue from 'vue'
 
 import mavlink2rest from '@/libs/MAVLink2Rest'
+import { MavType } from '@/libs/MAVLink2Rest/mavlink2rest-ts/messages/mavlink2rest-enum'
 import mavlink from '@/store/mavlink'
 import system_information from '@/store/system-information'
 import { RaspberryEventType } from '@/types/system-information/platform'
@@ -205,7 +206,7 @@ export default Vue.extend({
   },
   mounted() {
     mavlink2rest.startListening('HEARTBEAT').setCallback((message) => {
-      if (message?.header.system_id !== 1 || message?.header.component_id !== 1) {
+      if (!this.is_vehicle(message?.message.mavtype.type) || message?.header.component_id !== 1) {
         return
       }
 
@@ -215,6 +216,28 @@ export default Vue.extend({
   methods: {
     heartbeat_age(): number {
       return new Date().valueOf() - this.last_heartbeat_date.getTime()
+    },
+    is_vehicle(type: string) {
+      return [
+        MavType.MAV_TYPE_FIXED_WING,
+        MavType.MAV_TYPE_VTOL_DUOROTOR,
+        MavType.MAV_TYPE_VTOL_QUADROTOR,
+        MavType.MAV_TYPE_VTOL_TILTROTOR,
+        MavType.MAV_TYPE_VTOL_RESERVED4,
+        MavType.MAV_TYPE_VTOL_RESERVED5,
+        MavType.MAV_TYPE_QUADROTOR,
+        MavType.MAV_TYPE_COAXIAL,
+        MavType.MAV_TYPE_HELICOPTER,
+        MavType.MAV_TYPE_HEXAROTOR,
+        MavType.MAV_TYPE_OCTOROTOR,
+        MavType.MAV_TYPE_TRICOPTER,
+        MavType.MAV_TYPE_GROUND_ROVER,
+        MavType.MAV_TYPE_SURFACE_BOAT,
+        MavType.MAV_TYPE_SUBMARINE,
+        // The next two ones are not defined?
+        'MAV_TYPE_VTOL_FIXEDROTOR',
+        'MAV_TYPE_VTOL_TAILSITTER',
+      ].includes(type)
     },
   },
 })

--- a/core/libs/commonwealth/commonwealth/mavlink_comm/MavlinkComm.py
+++ b/core/libs/commonwealth/commonwealth/mavlink_comm/MavlinkComm.py
@@ -1,16 +1,20 @@
 import asyncio
 import json
 import os
+import re
 import time
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 import aiohttp
+from loguru import logger
 
 from commonwealth.mavlink_comm.exceptions import (
     FetchUpdatedMessageFail,
     MavlinkMessageReceiveFail,
     MavlinkMessageSendFail,
 )
+from commonwealth.mavlink_comm.typedefs import MavlinkVehicleType
 
 
 class MavlinkMessenger:
@@ -21,6 +25,7 @@ class MavlinkMessenger:
         self.m2r_address = "localhost:6040"
 
     def set_system_id(self, system_id: int) -> None:
+        logger.info(f"system_id set to: {system_id}")
         self.system_id = system_id
 
     def set_component_id(self, component_id: int) -> None:
@@ -38,10 +43,22 @@ class MavlinkMessenger:
     def m2r_rest_url(self) -> str:
         return f"http://{self.m2r_address}/mavlink"
 
+    async def get_all_mavlink(self) -> Any:
+        request_timeout = 1.0
+        async with aiohttp.ClientSession() as session:
+            try:
+                async with session.get(self.m2r_rest_url, timeout=request_timeout) as response:
+                    if not response.status == 200:
+                        raise MavlinkMessageReceiveFail(f"Received status code of {response.status}.")
+                    message = await response.json()
+            except asyncio.exceptions.TimeoutError as error:
+                raise MavlinkMessageReceiveFail(f"Request timed out after {request_timeout} second.") from error
+        return message
+
     async def get_mavlink_message(
-        self, message_name: Optional[str] = None, vehicle: Optional[int] = 1, component: Optional[int] = 1
+        self, message_name: Optional[str] = None, vehicle: Optional[int] = None, component: Optional[int] = 1
     ) -> Any:
-        request_url = f"{self.m2r_rest_url}/vehicles/{vehicle}/components/{component}/messages"
+        request_url = f"{self.m2r_rest_url}/vehicles/{vehicle or self.system_id}/components/{component}/messages"
         if message_name:
             request_url += f"/{message_name.upper()}"
 
@@ -51,28 +68,60 @@ class MavlinkMessenger:
                 async with session.get(request_url, timeout=request_timeout) as response:
                     if not response.status == 200:
                         raise MavlinkMessageReceiveFail(f"Received status code of {response.status}.")
+                    # if message is "None", try re-detecting systemid
+                    if await response.text() == "None":
+                        self.set_system_id(await self.get_most_recent_vehicle_id())
+                        raise MavlinkMessageReceiveFail("Received empty response")
                     message = await response.json()
             except asyncio.exceptions.TimeoutError as error:
                 raise MavlinkMessageReceiveFail(f"Request timed out after {request_timeout} second.") from error
 
         return message
 
+    async def get_most_recent_vehicle_id(self) -> int:
+        json_data = await self.get_all_mavlink()
+        most_recent_timestamp = datetime.min.replace(tzinfo=timezone.utc)
+        most_recent_vehicle_id = None
+        for vehicle_id, vehicle in json_data["vehicles"].items():
+
+            for component in vehicle["components"].values():
+                if "HEARTBEAT" in component["messages"]:
+                    message = component["messages"]["HEARTBEAT"]
+                    # we are looking for vehicles, not GCSs
+                    if not MavlinkVehicleType(message["mavtype"]["type"]).is_actually_vehicle():
+                        continue
+                    last_update_str = message["status"]["time"]["last_update"]
+                    # drop sub-microsecond precision as it is not supported by datetime.fromisoformat
+                    last_update_str = re.sub(r"(\.\d{6})\d+", r"\1", last_update_str)
+                    last_update = datetime.fromisoformat(last_update_str)
+
+                    if last_update > most_recent_timestamp:
+                        most_recent_timestamp = last_update
+                        most_recent_vehicle_id = vehicle_id
+        if most_recent_vehicle_id:
+            logger.debug(f"{most_recent_vehicle_id} (detected)")
+            return int(most_recent_vehicle_id)
+        logger.debug("no vehicle ID detected - using default (1)")
+        return 1
+
     async def get_updated_mavlink_message(
         self,
         message_name: str,
-        vehicle: int = 1,
+        vehicle: Optional[int] = None,
         component: int = 1,
         timeout: float = 10.0,
     ) -> Any:
-        first_message = await self.get_mavlink_message(message_name, vehicle, component)
+        first_message = await self.get_mavlink_message(message_name, vehicle or self.system_id, component)
         first_message_counter = first_message["status"]["time"]["counter"]
         t0 = time.time()
         while True:
-            new_message = await self.get_mavlink_message(message_name, vehicle, component)
+            new_message = await self.get_mavlink_message(message_name, vehicle or self.system_id, component)
             new_message_counter = new_message["status"]["time"]["counter"]
             if new_message_counter > first_message_counter:
                 break
-            if (time.time() - t0) > timeout:
+            if (time.time() - t0) > timeout / 2:
+                logger.warning(f"no new messages after {timeout/2} seconds, triggering system-id detection")
+                self.set_system_id(await self.get_most_recent_vehicle_id())
                 raise FetchUpdatedMessageFail(f"Did not receive an updated {message_name} before timeout.")
             await asyncio.sleep(timeout / 10.0)
 
@@ -91,6 +140,7 @@ class MavlinkMessenger:
                     self.m2r_rest_url, data=json.dumps(mavlink2rest_package), timeout=request_timeout
                 ) as response:
                     if not response.status == 200:
+                        logger.warning(await response.text())
                         raise MavlinkMessageSendFail(f"Received status code of {response.status}.")
             except asyncio.exceptions.TimeoutError as error:
                 raise MavlinkMessageSendFail(f"Request timed out after {request_timeout} second.") from error

--- a/core/libs/commonwealth/commonwealth/mavlink_comm/MavlinkComm.py
+++ b/core/libs/commonwealth/commonwealth/mavlink_comm/MavlinkComm.py
@@ -87,8 +87,8 @@ class MavlinkMessenger:
             for component in vehicle["components"].values():
                 if "HEARTBEAT" in component["messages"]:
                     message = component["messages"]["HEARTBEAT"]
-                    # we are looking for vehicles, not GCSs
-                    if not MavlinkVehicleType(message["mavtype"]["type"]).is_actually_vehicle():
+                    # we are looking for vehicles, not GCSs or other components
+                    if not MavlinkVehicleType(message["mavtype"]["type"]).is_actually_a_vehicle():
                         continue
                     last_update_str = message["status"]["time"]["last_update"]
                     # drop sub-microsecond precision as it is not supported by datetime.fromisoformat

--- a/core/libs/commonwealth/commonwealth/mavlink_comm/typedefs.py
+++ b/core/libs/commonwealth/commonwealth/mavlink_comm/typedefs.py
@@ -110,6 +110,9 @@ class MavlinkVehicleType(str, Enum):
 
         return "Unknown"
 
+    def is_actually_a_vehicle(self) -> bool:
+        return self.mavlink_firmware_type() in ["ArduPlane", "ArduCopter", "ArduRover", "ArduSub"]
+
 
 class FirmwareInfo(BaseModel):
     version: str


### PR DESCRIPTION
This goes on the assumption that the vehicle is only one system with multiple components.
it relies on mavlink2rest to detect the most recent message received and locks on to that ID

Relevant to #1466