### PR TITLE
core: services: ardupilot_manager: setup: Fix unnecessary download

### DIFF
--- a/core/services/ardupilot_manager/setup.py
+++ b/core/services/ardupilot_manager/setup.py
@@ -37,7 +37,6 @@ static_files = [
     ),
     StaticFile(static_folder, "mif/metro.woff", "https://cdnjs.cloudflare.com/ajax/libs/metro/4.4.3/mif/metro.woff"),
     StaticFile(static_folder, "mif/metro.ttf", "https://cdnjs.cloudflare.com/ajax/libs/metro/4.4.3/mif/metro.ttf"),
-    StaticFile(defaults_folder, "ardupilot_navigator", "https://firmware.ardupilot.org/Sub/beta/navigator/ardusub"),
     StaticFile(
         defaults_folder,
         "ardupilot_navigator",


### PR DESCRIPTION
It's being overwritten by the following one 