### PR TITLE
core: nginx: override CORS header for mavlink2rest

### DIFF
--- a/core/tools/nginx/nginx.conf
+++ b/core/tools/nginx/nginx.conf
@@ -126,6 +126,12 @@ http {
         }
 
         location /mavlink2rest {
+            # Hide the header from the upstream application
+            proxy_hide_header Access-Control-Allow-Origin;
+
+            # Add the desired header value
+            add_header Access-Control-Allow-Origin *;
+
             rewrite ^/mavlink2rest$ /mavlink2rest/ redirect;
             rewrite ^/mavlink2rest/(.*)$ /$1 break;
             proxy_pass http://127.0.0.1:6040;


### PR DESCRIPTION
Fixes this issue:

<img width="602" alt="Screenshot 2023-04-15 at 00 53 23" src="https://user-images.githubusercontent.com/4013804/232181667-b42d9029-18c6-4e52-914d-bc7ba6569b44.png">