### PR TITLE
Support non-navigator linux boards (initially Argonot)

### DIFF
--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -15,6 +15,7 @@ from loguru import logger
 from exceptions import (
     ArdupilotProcessKillFail,
     EndpointAlreadyExists,
+    NoDefaultFirmwareAvailable,
     NoPreferredBoardSet,
 )
 from firmware.FirmwareManagement import FirmwareManager
@@ -173,6 +174,10 @@ class ArduPilotManager(metaclass=Singleton):
                 self.firmware_manager.install_firmware_from_file(
                     pathlib.Path("/root/blueos-files/ardupilot-manager/default/ardupilot_navigator"),
                     board,
+                )
+            else:
+                raise NoDefaultFirmwareAvailable(
+                    f"No firmware installed for '{board.platform}' and no default firmware available. Please install the firmware manually."
                 )
 
         firmware_path = self.firmware_manager.firmware_path(self._current_board.platform)

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -166,7 +166,7 @@ class ArduPilotManager(metaclass=Singleton):
         cmdlines = [f"-{entry.port} {entry.endpoint}" for entry in self.get_serials()]
         return " ".join(cmdlines)
 
-    def start_navigator(self, board: FlightController) -> None:
+    def start_linux_board(self, board: FlightController) -> None:
         self._current_board = board
         if not self.firmware_manager.is_firmware_installed(self._current_board):
             if board.platform == Platform.Navigator:
@@ -459,8 +459,8 @@ class ArduPilotManager(metaclass=Singleton):
             flight_controller = self.get_board_to_be_used(available_boards)
             logger.info(f"Using {flight_controller.name} flight-controller.")
 
-            if flight_controller.platform == Platform.Navigator:
-                self.start_navigator(flight_controller)
+            if flight_controller.platform.type == PlatformType.Linux:
+                self.start_linux_board(flight_controller)
             elif flight_controller.platform.type == PlatformType.Serial:
                 self.start_serial(flight_controller)
             elif flight_controller.platform == Platform.SITL:

--- a/core/services/ardupilot_manager/firmware/FirmwareInstall.py
+++ b/core/services/ardupilot_manager/firmware/FirmwareInstall.py
@@ -37,6 +37,7 @@ def get_correspondent_decoder_platform(current_platform: Platform) -> Union[Boar
     correspondent_decoder_platform = {
         Platform.SITL: BoardType.SITL,
         Platform.Navigator: BoardSubType.LINUX_NAVIGATOR,
+        Platform.Argonot: BoardSubType.LINUX_NAVIGATOR,
     }
     return correspondent_decoder_platform.get(current_platform, BoardType.EMPTY)
 

--- a/core/services/ardupilot_manager/flight_controller_detector/Detector.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/Detector.py
@@ -38,10 +38,22 @@ class Detector:
             except Exception:
                 return False
 
+        def is_argonot_r1_connected() -> bool:
+            try:
+                bus = SMBus(1)
+                swap_multiplexer_address = 0x77
+                bus.read_byte_data(swap_multiplexer_address, 0)
+                return True
+            except Exception:
+                return False
+
         logger.debug("Trying to detect Linux board.")
         if is_navigator_r5_connected():
             logger.debug("Navigator R5 detected.")
             return FlightController(name="Navigator", manufacturer="Blue Robotics", platform=Platform.Navigator)
+        if is_argonot_r1_connected():
+            logger.debug("Argonot R1 detected.")
+            return FlightController(name="Argonot", manufacturer="SymbyTech", platform=Platform.Argonot)
         logger.debug("No Linux board detected.")
         return None
 

--- a/core/services/ardupilot_manager/flight_controller_detector/Detector.py
+++ b/core/services/ardupilot_manager/flight_controller_detector/Detector.py
@@ -11,8 +11,8 @@ from typedefs import FlightController, FlightControllerFlags, Platform
 
 class Detector:
     @staticmethod
-    def detect_navigator() -> Optional[FlightController]:
-        """Returns Navigator board if connected.
+    def detect_linux_board() -> Optional[FlightController]:
+        """Returns Linux board if connected.
         Check for connection using the sensors on the I²C and SPI buses.
 
         Returns:
@@ -38,11 +38,11 @@ class Detector:
             except Exception:
                 return False
 
-        logger.debug("Trying to detect Navigator board.")
+        logger.debug("Trying to detect Linux board.")
         if is_navigator_r5_connected():
             logger.debug("Navigator R5 detected.")
             return FlightController(name="Navigator", manufacturer="Blue Robotics", platform=Platform.Navigator)
-        logger.debug("No Navigator board detected.")
+        logger.debug("No Linux board detected.")
         return None
 
     @staticmethod
@@ -106,9 +106,9 @@ class Detector:
         if not is_running_as_root():
             return available
 
-        navigator = cls.detect_navigator()
-        if navigator:
-            available.append(navigator)
+        linux_board = cls.detect_linux_board()
+        if linux_board:
+            available.append(linux_board)
 
         available.extend(cls().detect_serial_flight_controllers())
 

--- a/core/services/ardupilot_manager/typedefs.py
+++ b/core/services/ardupilot_manager/typedefs.py
@@ -109,6 +109,7 @@ class Platform(str, Enum):
     CubeOrange = "CubeOrange"
     GenericSerial = "GenericSerial"
     Navigator = "navigator"
+    Argonot = "argonot"
     SITL = get_sitl_platform_name(machine())
 
     @property
@@ -120,6 +121,7 @@ class Platform(str, Enum):
             Platform.CubeOrange: PlatformType.Serial,
             Platform.GenericSerial: PlatformType.Serial,
             Platform.Navigator: PlatformType.Linux,
+            Platform.Argonot: PlatformType.Linux,
             Platform.SITL: PlatformType.SITL,
         }
         return platform_types.get(self, PlatformType.Unknown)


### PR DESCRIPTION
With this small change, we can support running Ardupilot Linux-based firmwares for boards other than the Navigator.

This was motivated to support the Argonot system, from SymbyTech (a request from @DevinNorgarb).

The only downside for now is that when there's no firmware installed for that board, we will use the one we have stored for Navigator.

The PR is in draft mode until we confirm the sensors used to identify this board.

Fix #1623.