### PR TITLE
core: tools: mavlink-camera-manager: Update to t3.11.2.

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink-camera-manager"
 ARTIFACT_PREFIX="mavlink-camera-manager"
-VERSION=t3.11.1
+VERSION=t3.11.2
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/bluerobotics/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-armv7.zip"


### PR DESCRIPTION

* UDP latency from 192 to 128ms
* Reset now gently remove streams, which fixes the problem of not being able to create streams after calling the reset.

[Release notes](https://github.com/bluerobotics/mavlink-camera-manager/releases/tag/t3.11.2)