### PR TITLE
core: frontend: App: Make scroll smart

### DIFF
--- a/core/frontend/src/App.vue
+++ b/core/frontend/src/App.vue
@@ -624,6 +624,6 @@ div.pirate-marker.v-icon {
 }
 
 html {
-  overflow: hidden
+  overflow: auto
 }
 </style>


### PR DESCRIPTION
Only show scroll when necessary.
Different from #1637, where scroll will be visible in cases where the content is full visible. 