### PR TITLE
core: version chooser: update outdated link

### DIFF
--- a/core/frontend/src/components/version-chooser/VersionChooser.vue
+++ b/core/frontend/src/components/version-chooser/VersionChooser.vue
@@ -141,7 +141,7 @@
     >
       <h2>Manual upload</h2>
       Use this to upload a .tar docker image. These can be download from
-      <a href="https://github.com/bluerobotics/BlueOS-docker/actions/workflows/deploy.yml">Github's CI</a>
+      <a href="https://github.com/bluerobotics/BlueOS-docker/actions/workflows/test-and-deploy.yml">Github's CI</a>
       or generated locally using "docker save"
       <v-file-input
         v-if="!disable_upload_controls"


### PR DESCRIPTION
Not sure if it's too late to backport this, but it may help [people updating from old releases, if the remote isn't loading properly](https://discuss.bluerobotics.com/t/broken-link-to-githubs-ci-for-manual-upload/14108).