### PR TITLE
frontend: parameter-editor: Fix missing flag selection on editor

### DIFF
--- a/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
@@ -154,7 +154,7 @@ export default Vue.extend({
       // Form can't be computed correctly, so we save it's state under data
       is_form_valid: false,
       new_value: 0,
-      selected_bitflags: [],
+      selected_bitflags: [] as number[],
     }
   },
   computed: {
@@ -180,6 +180,7 @@ export default Vue.extend({
   },
   watch: {
     new_value(): void {
+      this.updateSelectedFlags()
       this.isFormValid()
     },
     edited_bitmask_value(): void {
@@ -230,6 +231,17 @@ export default Vue.extend({
         }
       }
       return true
+    },
+    updateSelectedFlags(): void {
+      const output = []
+      for (let v = 0; v < 64; v += 1) {
+        const bitmask_value = 2 ** v
+        // eslint-disable-next-line no-bitwise
+        if (this.new_value & bitmask_value) {
+          output.push(bitmask_value)
+        }
+      }
+      this.selected_bitflags = output
     },
     async rebootVehicle(): Promise<void> {
       await this.restart_autopilot()


### PR DESCRIPTION
now:

![image](https://github.com/bluerobotics/BlueOS-docker/assets/1215497/9a966c09-8b95-4d26-9f9f-574c32bcd8e2)


before:

![image](https://github.com/bluerobotics/BlueOS-docker/assets/1215497/9e8c9b04-1c95-4a10-ada7-039017fc5bb0)
