### PR TITLE
core: frontend: componentes: PingInfo: Do not show if there is no device

### DIFF
--- a/core/frontend/src/components/vehiclesetup/overview/PingInfo.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/PingInfo.vue
@@ -1,5 +1,8 @@
 <template>
-  <v-card class="ma-2 pa-2 pinginfo">
+  <v-card
+    v-if="pings.length"
+    class="ma-2 pa-2 pinginfo"
+  >
     <v-card-title class="justify-center">
       Ping Sensors
     </v-card-title>


### PR DESCRIPTION
now:
![image](https://github.com/bluerobotics/BlueOS-docker/assets/1215497/4b59d3b8-7bac-4252-b592-c940c950788d)

before:
![image](https://github.com/bluerobotics/BlueOS-docker/assets/1215497/b5144882-1179-4aa8-8f7d-2abaa06a3107)
