### PR TITLE
Add interface for loading parameters

### DIFF
--- a/core/frontend/src/components/autopilot/AutopilotManagerUpdater.ts
+++ b/core/frontend/src/components/autopilot/AutopilotManagerUpdater.ts
@@ -4,6 +4,7 @@ import { SemVer } from 'semver'
 import Notifier from '@/libs/notifier'
 import autopilot from '@/store/autopilot_manager'
 import { Firmware, Vehicle } from '@/types/autopilot'
+import { Dictionary } from '@/types/common'
 import { autopilot_service } from '@/types/frontend_services'
 import back_axios from '@/utils/api'
 
@@ -129,7 +130,11 @@ export async function availableFirmwares(vehicleType: Vehicle): Promise<Firmware
     })
 }
 
-export async function installFirmwareFromUrl(url: URL, make_default: boolean | undefined): Promise<void> {
+export async function installFirmwareFromUrl(
+  url: URL,
+  make_default: boolean | undefined,
+  default_params?: Dictionary<number>,
+): Promise<void> {
   return back_axios({
     method: 'post',
     url: `${autopilot.API_URL}/install_firmware_from_url`,
@@ -138,6 +143,9 @@ export async function installFirmwareFromUrl(url: URL, make_default: boolean | u
       // eslint-disable-next-line object-shorthand
       url: url,
       make_default: make_default ?? false,
+    },
+    data: {
+      params: default_params ?? {},
     },
   })
     .then((response) => response.data)

--- a/core/frontend/src/components/parameter-editor/ParameterEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditor.vue
@@ -128,18 +128,11 @@
 
         <v-card-actions>
           <v-spacer />
-          <v-btn
-            color="primary"
-            @click="load_param_dialog = false"
-          >
-            Cancel
-          </v-btn>
-          <v-btn
-            color="primary"
-            @click="applyParameterFile"
-          >
-            Save and Reboot
-          </v-btn>
+          <parameter-loader
+            v-if="loaded_parameters"
+            :parameters="loaded_parameter"
+            @done="loaded_parameter = {}; load_param_dialog = false"
+          />
         </v-card-actions>
       </v-card>
     </v-dialog>
@@ -152,17 +145,19 @@ import { saveAs } from 'file-saver'
 import Fuse from 'fuse.js'
 import Vue from 'vue'
 
-import mavlink2rest from '@/libs/MAVLink2Rest'
 import autopilot_data from '@/store/autopilot'
 import autopilot from '@/store/autopilot_manager'
-import Parameter, { ParamType, printParam } from '@/types/autopilot/parameter'
+import Parameter, { printParam } from '@/types/autopilot/parameter'
+import { Dictionary } from '@/types/common'
 
 import ParameterEditorDialog from './ParameterEditorDialog.vue'
+import ParameterLoader from './ParameterLoader.vue'
 
 export default Vue.extend({
   name: 'ParameterEditor',
   components: {
     ParameterEditorDialog,
+    ParameterLoader,
   },
   data() {
     return {
@@ -170,7 +165,7 @@ export default Vue.extend({
       edited_param: undefined as (undefined | Parameter),
       edit_dialog: false,
       load_param_dialog: false,
-      loaded_parameter: [] as {name: string, value: number, type: undefined | ParamType}[],
+      loaded_parameter: {} as Dictionary<number>,
     }
   },
   computed: {

--- a/core/frontend/src/components/parameter-editor/ParameterEditor.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditor.vue
@@ -295,7 +295,7 @@ export default Vue.extend({
     },
     applyParameterFile(): void {
       for (const param of this.loaded_parameter) {
-        mavlink2rest.setParam(param.name, param.value, param.type)
+        mavlink2rest.setParam(param.name, param.value, autopilot_data.system_id, param.type)
       }
       this.load_param_dialog = false
     },

--- a/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
@@ -287,7 +287,7 @@ export default Vue.extend({
         value = this.new_value
       }
 
-      mavlink2rest.setParam(this.param.name, value, this.param.paramType.type)
+      mavlink2rest.setParam(this.param.name, value, autopilot_data.system_id, this.param.paramType.type)
 
       if (reboot) {
         await this.rebootVehicle()

--- a/core/frontend/src/components/parameter-editor/ParameterLoader.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterLoader.vue
@@ -76,7 +76,7 @@
           </template>
         </v-progress-linear>
       </v-card-text>
-      <v-card-text v-else-if="writing">
+      <v-card-text v-else-if="write_finished">
         <v-alert
           type="success"
         >
@@ -152,6 +152,9 @@ export default Vue.extend({
     },
     user_selected_params_length(): number {
       return Object.keys(this.user_selected_params).length
+    },
+    write_finished(): boolean {
+      return this.user_selected_params_length === 0
     },
   },
   watch: {

--- a/core/frontend/src/components/parameter-editor/ParameterLoader.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterLoader.vue
@@ -1,0 +1,318 @@
+<template>
+  <v-dialog
+    v-model="should_open"
+    width="fit-content"
+    max-width="80%"
+    @click:outside="done"
+  >
+    <v-card>
+      <v-card-title class="pt-6">
+        Loading Parameters
+      </v-card-title>
+      <v-card-text v-if="Object.keys(different_param_set).length !== 0">
+        <v-row class="virtual-table-row">
+          <v-col class="virtual-table-cell checkbox-cell">
+            <v-checkbox
+              ref="selectAllCheckbox"
+              v-model="select_all"
+              class="virtual-table-cell"
+              label="Write"
+              :disabled="writing"
+              :indeterminate="select_all === null"
+              @click="toggleSelectAll"
+            />
+          </v-col>
+          <v-col class="virtual-table-cell name-cell">
+            <strong>Name</strong>
+          </v-col>
+          <v-col class="virtual-table-cell">
+            <strong>Value</strong>
+          </v-col>
+          <v-col class="virtual-table-cell">
+            <strong>New Value</strong>
+          </v-col>
+        </v-row>
+        <!-- display all parameters in a concise table using virtual scroller -->
+        <v-virtual-scroll
+          :items="printable(different_param_set)"
+          height="300"
+          item-height="30"
+          class="virtual-table"
+        >
+          <template #default="{ item }">
+            <v-row class="virtual-table-row">
+              <v-col class="virtual-table-cell">
+                <v-checkbox
+                  v-model="param_checkboxes[item.name]"
+                  class="checkbox-label checkbox-cell"
+                  :disabled="writing"
+                />
+              </v-col>
+              <v-col class="virtual-table-cell name-cell">
+                {{ item.name }}
+              </v-col>
+              <v-col class="virtual-table-cell">
+                {{ printParam(item.current_value) }}
+              </v-col>
+              <v-col class="virtual-table-cell">
+                {{ printParam(item.value) }}
+              </v-col>
+            </v-row>
+          </template>
+        </v-virtual-scroll>
+        <v-progress-linear
+          v-if="user_selected_params_length > 0 && initial_size > 0"
+          slot="progress"
+          :color="error ? 'red' : 'blue'"
+          height="20"
+          :value="progress"
+        >
+          <template #default>
+            <strong
+              class="ml-5"
+            >
+              {{ user_selected_params_length }} to go
+            </strong>
+          </template>
+        </v-progress-linear>
+      </v-card-text>
+      <v-card-text v-else-if="writing">
+        <v-alert
+          type="success"
+        >
+          Parameters written successfully
+        </v-alert>
+      </v-card-text>
+      <v-card-text v-else>
+        No parameters to change. This means all the
+        parameters in this group are already set to the desired values
+      </v-card-text>
+      <v-card-text v-if="error">
+        <v-alert
+          type="error"
+        >
+          {{ error }}
+        </v-alert>
+      </v-card-text>
+      <v-card-actions class="justify-center">
+        <v-btn
+          :disabled="user_selected_params_length === 0 || writing"
+          class="ma-6 elevation-2"
+          x-large
+          color="primary"
+          @click="writeParams"
+        >
+          Write Parameters
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script lang="ts">
+import Vue, { PropType } from 'vue'
+import { Dictionary } from 'vue-router/types/router'
+
+import mavlink2rest from '@/libs/MAVLink2Rest'
+import autopilot_data from '@/store/autopilot'
+
+export default Vue.extend({
+  name: 'ParameterLoader',
+  props: {
+    parameters: {
+      type: Object as PropType<Dictionary<number>> | undefined,
+      default: undefined,
+    },
+  },
+  data: () => ({
+    initial_size: 0,
+    param_checkboxes: {} as Dictionary<boolean>,
+    select_all: true as boolean | null,
+    retries: 0,
+    retry_interval: 0,
+    should_open: false,
+    error: false as boolean | string,
+    writing: false,
+  }),
+  computed: {
+    progress(): number {
+      return 100 - this.different_param_set_length / this.initial_size * 100
+    },
+    writeable_param_set(): Dictionary<number> {
+      return this.filterParamsByReadOnly(this.parameters)
+    },
+    different_param_set(): Dictionary<number> {
+      return this.filterParamsByValue(this.writeable_param_set)
+    },
+    user_selected_params(): Dictionary<number> {
+      return this.filterParamsBySelection(this.different_param_set)
+    },
+    different_param_set_length(): number {
+      return Object.keys(this.different_param_set).length
+    },
+    user_selected_params_length(): number {
+      return Object.keys(this.user_selected_params).length
+    },
+  },
+  watch: {
+    param_checkboxes: {
+      deep: true,
+      handler() {
+        this.updateSelectAllStatus()
+      },
+    },
+    parameters: {
+      handler(newval) {
+        if (Object.keys(this.writeable_param_set).length !== 0) {
+          this.should_open = true
+        }
+        this.updateParamCheckboxes(newval)
+      },
+    },
+  },
+  methods: {
+    done() {
+      this.$emit('done')
+      this.error = false
+      this.retries = 0
+      setTimeout(() => {
+        // delay this as the dialog is still open when the done event is emitted
+        // which couses the text to change during the close animation
+        this.writing = false
+      }, 500)
+      this.initial_size = 0
+      this.should_open = false
+    },
+    toggleSelectAll() {
+      const new_value = this.select_all === null ? true : this.select_all
+      for (const key of Object.keys(this.param_checkboxes)) {
+        this.$set(this.param_checkboxes, key, new_value)
+      }
+    },
+    printParam(value: number) {
+      try {
+        if (Math.abs(value) > 1e4) {
+          return value.toExponential(3)
+        }
+        if (Math.abs(value) < 0.01 && value !== 0) {
+          return value.toExponential(3)
+        }
+        return value.toFixed(2)
+      } catch {
+        return 'N/A'
+      }
+    },
+    printable(paramset: Dictionary<number>) {
+      return this.createPrintableParams(paramset)
+    },
+    writeParams() {
+      this.writing = true
+      this.initial_size = this.user_selected_params_length
+      this.writeSelectedParams()
+      this.retry_interval = setInterval(() => {
+        if (this.user_selected_params_length) {
+          this.retries += 1
+          if (this.retries > 5) {
+            clearInterval(this.retry_interval)
+            this.retries = 0
+            this.error = 'Failed to write some parameters. Please restart the vehicle and try again.'
+            return
+          }
+          this.writeSelectedParams()
+        } else {
+          clearInterval(this.retry_interval)
+        }
+      }, 1000)
+    },
+    writeSelectedParams() {
+      for (const [name, value] of Object.entries(this.user_selected_params)) {
+        this.writeParam(name, value)
+      }
+    },
+    writeParam(name: string, value: number) {
+      mavlink2rest.setParam(name, value)
+    },
+    filterParamsByReadOnly(params: Dictionary<number>): Dictionary<number> {
+      return Object.fromEntries(
+        Object.entries(params).filter(([name]) => {
+          const param = autopilot_data.parameter(name)
+          return !param?.readonly ?? true
+        }),
+      )
+    },
+    filterParamsByValue(params: Dictionary<number>): Dictionary<number> {
+      return Object.fromEntries(
+        Object.entries(params).filter(([name, value]) => {
+          const param = autopilot_data.parameter(name)
+          if (!param) {
+            return true
+          }
+          return Math.abs(param.value - value) > 0.0001
+        }),
+      )
+    },
+    filterParamsBySelection(params: Dictionary<number>): Dictionary<number> {
+      return Object.fromEntries(
+        Object.entries(params).filter(([name]) => this.param_checkboxes[name]),
+      )
+    },
+    updateSelectAllStatus() {
+      const all_checked = Object.values(this.param_checkboxes).every((val) => val)
+      const some_checked = Object.values(this.param_checkboxes).some((val) => val)
+      // eslint-disable-next-line no-nested-ternary
+      this.select_all = all_checked ? true : some_checked ? null : false
+    },
+    updateParamCheckboxes(params: Dictionary<number>) {
+      for (const [name, _value] of Object.entries(params)) {
+        this.$set(this.param_checkboxes, name, true)
+      }
+    },
+    createPrintableParams(paramset: Dictionary<number>) {
+      return Object.entries(paramset).map(([name, value]) => ({
+        name,
+        value,
+        current_value: autopilot_data.parameter(name)?.value,
+      }))
+    },
+  },
+})
+</script>
+<style scoped>
+button {
+    margin: 10px;
+}
+
+.virtual-table-row {
+  display: flex;
+  margin: 0;
+  margin-bottom: 15px;
+  border-bottom: 1px solid #eee;
+  flex-wrap: nowrap;
+}
+
+.virtual-table-cell {
+  flex: 1;
+  padding: 5px;
+  height: 30px;
+  min-width: 100px;
+}
+.virtual-table-cell .v-input {
+  margin-top: -6px;
+}
+
+.checkbox-label label {
+  font-weight: 700;
+}
+
+.name-cell {
+  min-width: 200px;
+}
+
+.checkbox-cell {
+  width: 50px;
+}
+
+.virtual-table {
+  overflow-x: hidden;
+}
+</style>

--- a/core/frontend/src/components/parameter-editor/ParameterLoader.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterLoader.vue
@@ -233,7 +233,7 @@ export default Vue.extend({
       }
     },
     writeParam(name: string, value: number) {
-      mavlink2rest.setParam(name, value)
+      mavlink2rest.setParam(name, value, autopilot_data.system_id)
     },
     filterParamsByReadOnly(params: Dictionary<number>): Dictionary<number> {
       return Object.fromEntries(

--- a/core/frontend/src/components/parameter-editor/ParameterLoader.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterLoader.vue
@@ -76,7 +76,7 @@
           </template>
         </v-progress-linear>
       </v-card-text>
-      <v-card-text v-else-if="write_finished">
+      <v-card-text v-else-if="write_finished && initial_size > 0">
         <v-alert
           type="success"
         >

--- a/core/frontend/src/components/vehiclesetup/Configure.vue
+++ b/core/frontend/src/components/vehiclesetup/Configure.vue
@@ -1,0 +1,56 @@
+<template>
+  <div>
+    <v-row class="mt-5">
+      <v-col
+        cols="12"
+        sm="7"
+      >
+        <v-card class="pa-5 ma-2">
+          <vehicle-viewer
+            noannotations
+            :autorotate="true"
+          />
+        </v-card>
+      </v-col>
+      <v-col
+        cols="12"
+        sm="5"
+      >
+        <vehicle-info :autorotate="true" />
+        <param-sets />
+      </v-col>
+    </v-row>
+    <v-sheet class="d-flex">
+      <lights-info />
+      <gripper-info />
+      <leak-info />
+      <power-info />
+    </v-sheet>
+  </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue'
+
+import VehicleInfo from '@/components/vehiclesetup/overview/VehicleInfo.vue'
+import VehicleViewer from '@/components/vehiclesetup/viewers/VehicleViewer.vue'
+
+import GripperInfo from './overview/gripper.vue'
+import LeakInfo from './overview/LeakInfo.vue'
+import LightsInfo from './overview/LightsInfo.vue'
+import ParamSets from './overview/ParamSets.vue'
+import PowerInfo from './overview/PowerInfo.vue'
+
+export default Vue.extend({
+  name: 'Configure',
+  components: {
+    VehicleViewer,
+    VehicleInfo,
+    GripperInfo,
+    PowerInfo,
+    LightsInfo,
+    LeakInfo,
+    ParamSets,
+  },
+})
+</script>

--- a/core/frontend/src/components/vehiclesetup/overview/ParamSets.vue
+++ b/core/frontend/src/components/vehiclesetup/overview/ParamSets.vue
@@ -1,0 +1,124 @@
+<template>
+  <v-card class="ma-2 pa-2">
+    <v-card-title class="align-center">
+      Load Default Parameters
+    </v-card-title>
+    <v-card-text>
+      <v-btn
+        v-for="(paramSet, name) in filtered_param_sets"
+        :key="name"
+        color="primary"
+        @click="loadParams(name, paramSet)"
+      >
+        {{ name.split('/').pop() }}
+      </v-btn>
+      <p v-if="(Object.keys(filtered_param_sets).length === 0)">
+        No parameters available for this setup
+      </p>
+    </v-card-text>
+    <parameterloader
+      v-if="selected_paramset"
+      :parameters="selected_paramset"
+      @done="selected_paramset = {}"
+    />
+  </v-card>
+</template>
+
+<script lang="ts">
+import { SemVer } from 'semver'
+import Vue from 'vue'
+import { Dictionary } from 'vue-router/types/router'
+
+import parameterloader from '@/components/parameter-editor/ParameterLoader.vue'
+import autopilot from '@/store/autopilot_manager'
+
+const REPOSITORY_URL = 'https://williangalvani.github.io/Blueos-Parameter-Repository/params_v1.json'
+
+export default Vue.extend({
+  name: 'ParamSets',
+  components: {
+    parameterloader,
+  },
+  data: () => ({
+    all_param_sets: {} as Dictionary<Dictionary<number>>,
+    selected_paramset: {} as Dictionary<number>,
+    selected_paramset_name: undefined as (undefined | string),
+  }),
+  computed: {
+    board(): string | undefined {
+      return autopilot.current_board?.name
+    },
+    vehicle(): string | null {
+      return autopilot.firmware_vehicle_type
+    },
+    version(): SemVer | undefined {
+      return autopilot.firmware_info?.version
+    },
+    filtered_param_sets(): Dictionary<Dictionary<number>> | undefined {
+      const fw_patch = `${this.vehicle}/${this.version}/${this.board}`
+      const fw_minor = `${this.vehicle}/${this.version?.major}.${this.version?.minor}/${this.board}`
+      const fw_major = `${this.vehicle}/${this.version?.major}/${this.board}`
+
+      // returns a new dict where the keys start with the fullname
+      // e.g. "ArduSub/BlueROV2/4.0.3" -> "ArduSub/BlueROV2/4.0.3/BlueROV2"
+
+      let fw_params = {}
+      // try to find a paramset that matches the firmware version, starting from patch and walking up to major
+      for (const string of [fw_patch, fw_minor, fw_major]) {
+        fw_params = Object.fromEntries(
+          Object.entries(this.all_param_sets).filter(
+            ([name]) => name.toLocaleLowerCase().includes(string.toLowerCase()),
+          ),
+        )
+        if (Object.keys(fw_params).length > 0) {
+          break
+        }
+      }
+      return {
+        ...fw_params,
+      }
+    },
+  },
+  mounted() {
+    this.loadParamSets()
+  },
+  methods: {
+    async loadParamSets() {
+      // fetch json file from https://williangalvani.github.io/Blueos-Parameter-Repository/params.json
+      // and parse it into a dictionary
+      const response = await fetch(REPOSITORY_URL)
+      const paramSets = await response.json()
+      this.all_param_sets = paramSets
+    },
+    async loadParams(name: string, paramset: Dictionary<number>) {
+      this.selected_paramset_name = name
+      this.selected_paramset = paramset
+    },
+  },
+})
+</script>
+<style scoped>
+button {
+    margin: 10px;
+}
+
+.virtual-table-row {
+  display: flex;
+  margin: 0;
+  margin-bottom: 15px;
+  border-bottom: 1px solid #eee;
+}
+
+.virtual-table-cell {
+  flex: 1;
+  padding: 5px;
+  height: 30px;
+}
+.virtual-table-cell .v-input {
+  margin-top: -6px;
+}
+
+.checkbox-label label {
+  font-weight: 700;
+}
+</style>

--- a/core/frontend/src/components/vehiclesetup/viewers/VehicleViewer.vue
+++ b/core/frontend/src/components/vehiclesetup/viewers/VehicleViewer.vue
@@ -26,7 +26,7 @@ export default Vue.extend({
     highlight: {
       type: Array<string>,
       required: false,
-      default: [],
+      default: () => [],
     },
     autorotate: {
       type: Boolean,

--- a/core/frontend/src/components/wizard/ActionStepper.vue
+++ b/core/frontend/src/components/wizard/ActionStepper.vue
@@ -25,7 +25,7 @@ export type ConfigurationStatus = string | undefined
 export interface Configuration {
   title: string,
   summary: string | undefined,
-  promise: Promise<ConfigurationStatus>
+  promise: () => Promise<ConfigurationStatus>
   message: undefined | string
   done: boolean
 }

--- a/core/frontend/src/components/wizard/DefaultParamLoader.vue
+++ b/core/frontend/src/components/wizard/DefaultParamLoader.vue
@@ -1,0 +1,174 @@
+<template>
+  <div class="d-flex flex-column align-center ma-5" style="width: 100%; height: 100%;">
+    <v-select
+      v-model="selectedParamSetName"
+      :items="filtered_param_sets_names"
+      item-text="sanitized"
+      item-value="full"
+      :loading="is_loading"
+      :label="parameters_label"
+      :disabled="isLoading || hasError || !version"
+      style="min-width: 70%;"
+      @change="setParamSet(filtered_param_sets[selectedParamSetName])"
+    />
+    <v-virtual-scroll
+      v-if="valueItems.length > 0"
+      class="flex-grow"
+      :items="valueItems"
+      height="200"
+      item-height="20"
+      style="min-width: 50%;"
+    >
+      <template #default="{ item }">
+        <v-list-item>
+          <v-list-item-content>
+            <v-list-item-title>{{ item.key }} {{ item.value }}</v-list-item-title>
+          </v-list-item-content>
+        </v-list-item>
+      </template>
+    </v-virtual-scroll>
+  </div>
+</template>
+
+<script lang="ts">
+import { SemVer } from 'semver'
+import Vue, { PropType } from 'vue'
+import { Dictionary } from 'vue-router/types/router'
+
+import autopilot from '@/store/autopilot_manager'
+import { Firmware, Vehicle } from '@/types/autopilot'
+import { callPeriodically, stopCallingPeriodically } from '@/utils/helper_functions'
+
+import { availableFirmwares, fetchCurrentBoard } from '../autopilot/AutopilotManagerUpdater'
+
+const REPOSITORY_URL = 'https://williangalvani.github.io/Blueos-Parameter-Repository/params_v1.json'
+
+export default Vue.extend({
+  name: 'DefaultParamLoader',
+  props: {
+    value: {
+      type: Object as PropType<Dictionary<number>>,
+      default: () => ({}),
+    },
+    vehicle: {
+      type: String,
+      required: true,
+    },
+  },
+  data: () => ({
+    all_param_sets: {} as Dictionary<Dictionary<number>>,
+    version: undefined as (undefined | SemVer),
+    selectedParamSet: {},
+    selectedParamSetName: '' as string,
+    isLoading: true,
+    hasError: false,
+    fetching_error: undefined as (undefined | string),
+  }),
+  computed: {
+    parameters_label(): string {
+      if (this.isLoading) {
+        return 'Loading...'
+      }
+      if (this.fetching_error) {
+        return 'Unable to fetch Firmware version'
+      }
+      return `Parameter Sets (${this.board} - ${this.vehicle} - ${this.version || '...'})`
+    },
+    is_loading() {
+      return this.isLoading || this.hasError
+    },
+    filtered_param_sets(): Dictionary<Dictionary<number>> | undefined {
+      const fw_patch = `${this.vehicle}/${this.version}/${this.board}`
+      const fw_minor = `${this.vehicle}/${this.version?.major}.${this.version?.minor}/${this.board}`
+      const fw_major = `${this.vehicle}/${this.version?.major}/${this.board}`
+
+      // returns a new dict where the keys start with the fullname
+      // e.g. "ArduSub/BlueROV2/4.0.3" -> "ArduSub/BlueROV2/4.0.3/BlueROV2"
+
+      let fw_params = {}
+      // try to find a paramset that matches the firmware version, starting from patch and walking up to major
+      for (const string of [fw_patch, fw_minor, fw_major]) {
+        fw_params = Object.fromEntries(
+          Object.entries(this.all_param_sets).filter(
+            ([name]) => name.toLocaleLowerCase().includes(string.toLowerCase()),
+          ),
+        )
+        if (Object.keys(fw_params).length > 0) {
+          break
+        }
+      }
+      return {
+        ...fw_params,
+        'No default parameters': {}, // Always include the "No default parameters" option
+      }
+    },
+    filtered_param_sets_names(): {full: string, sanitized: string}[] {
+      return Object.keys(this.filtered_param_sets ?? {}).map((full) => ({
+        full,
+        sanitized: full.split('/').pop()?.split('.')[0] || '',
+      }))
+    },
+    board(): string | undefined {
+      return autopilot.current_board?.name
+    },
+    valueItems(): { key: string, value: number }[] {
+      return Object.entries(this.value ?? {}).map(([key, value]) => ({ key, value }))
+    },
+  },
+
+  watch: {
+    vehicle() {
+      this.version = undefined
+      this.fetching_error = undefined
+      this.updateLatestFirmwareVersion().then((version: string) => {
+        this.version = new SemVer(version.split('-')[1])
+      })
+    },
+  },
+  mounted() {
+    this.loadParamSets().catch(() => {
+      this.hasError = true
+    }).finally(() => {
+      this.isLoading = false
+    })
+    callPeriodically(fetchCurrentBoard, 10000)
+    this.updateLatestFirmwareVersion().then((version: string) => {
+      this.version = new SemVer(version.split('-')[1])
+    })
+  },
+  beforeDestroy() {
+    stopCallingPeriodically(fetchCurrentBoard)
+  },
+  methods: {
+    updateLatestFirmwareVersion() {
+      return availableFirmwares(this.vehicle as Vehicle)
+        .then((firmwares: Firmware[]) => {
+          const found: Firmware | undefined = firmwares.find((firmware) => firmware.name.includes('STABLE'))
+          if (found === undefined) {
+            return `Failed to find a stable version for vehicle (${this.vehicle})`
+          }
+          return found.name
+        }).catch((error) => {
+          this.fetching_error = error
+          return 'unable to detect latest firmware version'
+        })
+    },
+    setParamSet(paramSet: Dictionary<number>) {
+      this.selectedParamSet = paramSet
+      this.$emit('input', paramSet)
+    },
+    async loadParamSets() {
+      try {
+        // fetch json file from https://williangalvani.github.io/Blueos-Parameter-Repository/params.json
+        // and parse it into a dictionary
+        const response = await fetch(REPOSITORY_URL)
+        const paramSets = await response.json()
+        this.all_param_sets = paramSets
+      } catch (error) {
+        this.hasError = true
+        throw error
+      }
+    },
+  },
+})
+</script>

--- a/core/frontend/src/components/wizard/RequireInternet.vue
+++ b/core/frontend/src/components/wizard/RequireInternet.vue
@@ -52,7 +52,7 @@ export default Vue.extend({
   computed: {
     status(): string {
       if (this.connected) {
-        return 'Waiting for internet'
+        return 'Internet is available'
       }
 
       return 'Please connect to a wifi network with internet'

--- a/core/frontend/src/libs/MAVLink2Rest/index.ts
+++ b/core/frontend/src/libs/MAVLink2Rest/index.ts
@@ -3,7 +3,6 @@
 
 import axios from 'axios'
 
-import autopilot_data from '@/store/autopilot'
 import { Dictionary } from '@/types/common'
 
 import Endpoint from './Endpoint'
@@ -136,7 +135,7 @@ class Mavlink2RestManager {
    * @param  {string} message name
    * @returns Listener
    */
-  requestMessageRate(message: string, rate:number): void {
+  requestMessageRate(message: string, rate:number, system_id: number): void {
     if (rate < 0) {
       console.warn(`Requested invalid message rate for ${message}: ${rate}`)
       return
@@ -164,7 +163,7 @@ class Mavlink2RestManager {
         command: {
           type: 'MAV_CMD_SET_MESSAGE_INTERVAL',
         },
-        target_system: autopilot_data.system_id,
+        target_system: system_id,
         target_component: 0,
         confirmation: 0,
       },
@@ -178,7 +177,7 @@ class Mavlink2RestManager {
    * @param {number} value Desired parameter value
    * @param {string} type Valid mavlink parameter type based on mavlink2rest
    */
-  setParam(name: string, value: number, type?: string): void {
+  setParam(name: string, value: number, sysid: number, type?: string): void {
     const param_name = [...name]
     while (param_name.length < 16) {
       param_name.push('\0')
@@ -193,7 +192,7 @@ class Mavlink2RestManager {
       message: {
         type: 'PARAM_SET',
         param_value: value,
-        target_system: autopilot_data.system_id,
+        target_system: sysid,
         target_component: 0,
         param_id: param_name,
         param_type: {

--- a/core/frontend/src/store/mavlink.ts
+++ b/core/frontend/src/store/mavlink.ts
@@ -9,6 +9,8 @@ import store from '@/store'
 import { Dictionary } from '@/types/common'
 import { MavlinkMessage } from '@/types/mavlink'
 
+import autopilot_data from './autopilot'
+
 interface messsageRefreshRate {
   messageName: string
   refreshRate: number
@@ -32,7 +34,7 @@ class MavlinkStore extends VuexModule {
       console.warn(`Invalid request rate requested for message ${messageName}@${refreshRate}Hz`)
     }
 
-    mavlink2rest.requestMessageRate(messageName, refreshRate)
+    mavlink2rest.requestMessageRate(messageName, refreshRate, autopilot_data.system_id)
     // Remove any listener that has a lower frequency than requested
     if (messageName in this.message_listeners) {
       const currentRate = this.message_listeners[messageName].frequency

--- a/core/frontend/src/types/autopilot.ts
+++ b/core/frontend/src/types/autopilot.ts
@@ -10,6 +10,7 @@ export enum Vehicle {
     Rover = 'Rover',
     Plane = 'Plane',
     Copter = 'Copter',
+    Other = 'Other',
 }
 
 export enum Platform {

--- a/core/frontend/src/types/parameter_repository.d.ts
+++ b/core/frontend/src/types/parameter_repository.d.ts
@@ -1,0 +1,4 @@
+declare module 'https://williangalvani.github.io/Blueos-Parameter-Repository/parameters.js' {
+  const parameters: Dictionary<Dictionary<number>>
+  export default parameters
+}

--- a/core/frontend/src/views/VehicleSetupView.vue
+++ b/core/frontend/src/views/VehicleSetupView.vue
@@ -22,6 +22,7 @@
       >
         <pwm-setup v-if="page.value === 'pwm_outputs'" />
         <setup-overview v-else-if="page.value === 'overview'" />
+        <configure v-else-if="page.value === 'configure'" />
       </v-tab-item>
     </v-tabs-items>
   </v-container>
@@ -31,6 +32,7 @@
 import Vue from 'vue'
 
 import { fetchFirmwareVehicleType, fetchVehicleType } from '@/components/autopilot/AutopilotManagerUpdater'
+import Configure from '@/components/vehiclesetup/Configure.vue'
 import PwmSetup from '@/components/vehiclesetup/PwmSetup.vue'
 import setupOverview from '@/components/vehiclesetup/SetupOverview.vue'
 import { callPeriodically, stopCallingPeriodically } from '@/utils/helper_functions'
@@ -46,6 +48,7 @@ export default Vue.extend({
   components: {
     PwmSetup,
     setupOverview,
+    Configure,
   },
   data() {
     return {
@@ -53,6 +56,7 @@ export default Vue.extend({
       pages: [
         { title: 'Overview', icon: 'mdi-view-dashboard-variant-outline', value: 'overview' },
         { title: 'PWM Outputs', icon: 'mdi-fan', value: 'pwm_outputs' },
+        { title: 'Configure', icon: 'mdi-cog', value: 'configure' },
       ] as Item[],
     }
   },


### PR DESCRIPTION
This add defaults parameters for BlueROV2, BlueBoat120, and Sitl (rover/sub).

https://github.com/bluerobotics/BlueOS-docker/assets/4013804/0654cb48-e8c5-4858-8526-f6a403cdfa80

I opted to have individual sets of parameters. The trickiest thing is the Pixhawk Servo assignments, which changes between standard and heavy, while also being different than Navigator.

I believe this will be a lot easier to maintain than having multiple individual files, one for each possible combination.

We _could_  use a code like this to actually generate the parameter files, but I believe this is more meaningful.

This does not try to fetch parameters from an online repository, though we _could_ do that later if we judge it necessary.

We could also have "maximum supported version" of firmware for blueos/parameters, but I am strongly against it, as the parameter changes in ArduSub _should_ never be so severe as to cause breakages. Also, gnome does this and I'm tired of manually updating the "supported version" of my extensions so I can enable them again.

The blueboat params are currently a full dump, which I expect to cleanup as soon as I'm cleared to do so.

The sensors Infos are the bottom were kept as they are useful to see parameter changes.

on a next PRs, I intend to add both a progress bar and an option to filter the table to show only the parameters that will be changed (instead of the whole set). We also still need an option to "reset to firmware defaults".

fix #1060 
fix #1734 
should fix #1725 
fix #1750