### PR TITLE
Show correct name of image for an installed extension

### DIFF
--- a/core/frontend/src/components/kraken/InstalledExtensionCard.vue
+++ b/core/frontend/src/components/kraken/InstalledExtensionCard.vue
@@ -8,7 +8,7 @@
       </v-overlay>
     </template>
     <v-card-title class="pb-0">
-      {{ extension.docker.split('/')[1] }} <span
+      {{ extension.docker.split('/').pop() }} <span
         class="ml-3"
         style="color: grey;"
       > {{ extension.tag }}</span>


### PR DESCRIPTION
Previously, we used the second slash-separated path component instead of the last one for the image name.

This is incorrect as, e.g. in the below example. The name of the image identified by "docker.io/library/alpine" is "alpine", not "library"

![image](https://github.com/bluerobotics/BlueOS-docker/assets/119948/b539615a-275c-41e4-930b-80f956f9ee29)
