### PR TITLE
Set the default firmware during the wizard

### DIFF
--- a/core/frontend/src/components/autopilot/AutopilotManagerUpdater.ts
+++ b/core/frontend/src/components/autopilot/AutopilotManagerUpdater.ts
@@ -129,7 +129,7 @@ export async function availableFirmwares(vehicleType: Vehicle): Promise<Firmware
     })
 }
 
-export async function installFirmwareFromUrl(url: URL): Promise<void> {
+export async function installFirmwareFromUrl(url: URL, make_default: boolean | undefined): Promise<void> {
   return back_axios({
     method: 'post',
     url: `${autopilot.API_URL}/install_firmware_from_url`,
@@ -137,6 +137,7 @@ export async function installFirmwareFromUrl(url: URL): Promise<void> {
     params: {
       // eslint-disable-next-line object-shorthand
       url: url,
+      make_default: make_default ?? false,
     },
   })
     .then((response) => response.data)

--- a/core/frontend/src/components/wizard/Wizard.vue
+++ b/core/frontend/src/components/wizard/Wizard.vue
@@ -429,7 +429,7 @@ export default Vue.extend({
           if (found === undefined) {
             return `Failed to find a stable version for vehicle (${vehicle})`
           }
-          return installFirmwareFromUrl(found.url)
+          return installFirmwareFromUrl(found.url, true)
             .then(() => undefined)
             .catch((error) => `Failed to install firmware: ${error.message ?? error.response?.data}.`)
         })

--- a/core/services/ardupilot_manager/ArduPilotManager.py
+++ b/core/services/ardupilot_manager/ArduPilotManager.py
@@ -56,7 +56,9 @@ class ArduPilotManager(metaclass=Singleton):
         self.configuration = deepcopy(self.settings.content)
         self._load_endpoints()
         self.ardupilot_subprocess: Optional[Any] = None
-        self.firmware_manager = FirmwareManager(self.settings.firmware_folder, self.settings.defaults_folder)
+        self.firmware_manager = FirmwareManager(
+            self.settings.firmware_folder, self.settings.defaults_folder, self.settings.user_firmware_folder
+        )
         self.vehicle_manager = VehicleManager()
 
         self.should_be_running = False
@@ -535,8 +537,8 @@ class ArduPilotManager(metaclass=Singleton):
     def install_firmware_from_file(self, firmware_path: pathlib.Path, board: FlightController) -> None:
         self.firmware_manager.install_firmware_from_file(firmware_path, board)
 
-    def install_firmware_from_url(self, url: str, board: FlightController) -> None:
-        self.firmware_manager.install_firmware_from_url(url, board)
+    def install_firmware_from_url(self, url: str, board: FlightController, make_default: bool = False) -> None:
+        self.firmware_manager.install_firmware_from_url(url, board, make_default)
 
     def restore_default_firmware(self, board: FlightController) -> None:
         self.firmware_manager.restore_default_firmware(board)

--- a/core/services/ardupilot_manager/main.py
+++ b/core/services/ardupilot_manager/main.py
@@ -144,10 +144,10 @@ def get_available_firmwares(vehicle: Vehicle, board_name: Optional[str] = None) 
 
 @app.post("/install_firmware_from_url", summary="Install firmware for given URL.")
 @version(1, 0)
-async def install_firmware_from_url(url: str, board_name: Optional[str] = None) -> Any:
+async def install_firmware_from_url(url: str, board_name: Optional[str] = None, make_default: bool = False) -> Any:
     try:
         await autopilot.kill_ardupilot()
-        autopilot.install_firmware_from_url(url, target_board(board_name))
+        autopilot.install_firmware_from_url(url, target_board(board_name), make_default)
     finally:
         await autopilot.start_ardupilot()
 

--- a/core/services/ardupilot_manager/settings.py
+++ b/core/services/ardupilot_manager/settings.py
@@ -14,8 +14,9 @@ class Settings:
     settings_path = Path(appdirs.user_config_dir(app_name))
     settings_file = Path.joinpath(settings_path, "settings.json")
     firmware_folder = Path.joinpath(settings_path, "firmware")
+    user_firmware_folder = Path("/usr/blueos/userdata/firmware")
     log_path = Path.joinpath(settings_path, "logs")
-    app_folders = [settings_path, firmware_folder, log_path]
+    app_folders = [settings_path, firmware_folder, log_path, user_firmware_folder]
 
     blueos_files_folder = Path.joinpath(Path.home(), "blueos-files")
     defaults_folder = Path.joinpath(blueos_files_folder, "ardupilot-manager/default")


### PR DESCRIPTION
This will save the firmware downloaded during the wizard as the default fw in userdata.
we'll still fallback to a fw in the docker container

fix #1729 

image will be up at williangalvani/blueos-core : default_fw as soon as [this](https://github.com/Williangalvani/blueos-docker/actions/runs/5192546688/jobs/9362068931) finishes.


to test, make sure you are using a beta fw, then go through the wizard
after the wizard, you will have sub 4.1.0. switch to a beta again.
now click "restore default firmware" it should get you back to 4.1.0