### PR TITLE
Allow embedding parameters into firmware

### DIFF
--- a/core/frontend/src/components/autopilot/AutopilotManagerUpdater.ts
+++ b/core/frontend/src/components/autopilot/AutopilotManagerUpdater.ts
@@ -117,7 +117,7 @@ export async function availableFirmwares(vehicleType: Vehicle): Promise<Firmware
   return back_axios({
     method: 'get',
     url: `${autopilot.API_URL}/available_firmwares`,
-    timeout: 30000,
+    timeout: 60000,
     params: {
       vehicle: vehicleType,
     },

--- a/core/frontend/src/components/autopilot/AutopilotManagerUpdater.ts
+++ b/core/frontend/src/components/autopilot/AutopilotManagerUpdater.ts
@@ -138,7 +138,7 @@ export async function installFirmwareFromUrl(
   return back_axios({
     method: 'post',
     url: `${autopilot.API_URL}/install_firmware_from_url`,
-    timeout: 30000,
+    timeout: 120000,
     params: {
       // eslint-disable-next-line object-shorthand
       url: url,

--- a/core/services/ardupilot_manager/typedefs.py
+++ b/core/services/ardupilot_manager/typedefs.py
@@ -3,7 +3,7 @@ import re
 from enum import Enum, auto
 from pathlib import Path
 from platform import machine
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 
 from pydantic import BaseModel, validator
 
@@ -131,6 +131,10 @@ class FlightControllerFlags(str, Enum):
     """Flags for the Flight-controller class."""
 
     is_bootloader = "is_bootloader"
+
+
+class Parameters(BaseModel):
+    params: Dict[str, float]
 
 
 class FlightController(BaseModel):

--- a/core/tools/ardupilot_tools/bootstrap.sh
+++ b/core/tools/ardupilot_tools/bootstrap.sh
@@ -27,3 +27,12 @@ COMMIT_HASH=b839ddcc00f4cb89d89aaa8cf0cb03298d2f00b4
 LOCAL_PATH_DECODER="${USER_SITE_PACKAGES}/ardupilot_fw_decoder.py"
 REMOTE_URL_DECODER="https://raw.githubusercontent.com/ArduPilot/ardupilot/${COMMIT_HASH}/Tools/scripts/firmware_version_decoder.py"
 wget "$REMOTE_URL_DECODER" -O "$LOCAL_PATH_DECODER"
+
+
+### Ardupilot's apj_tool is used to embed params into apj files
+COMMIT_HASH=b839ddcc00f4cb89d89aaa8cf0cb03298d2f00b4
+LOCAL_PATH_APJ_TOOL="/usr/bin/apj_tool.py"
+REMOTE_URL_APJ_TOOL="https://raw.githubusercontent.com/ArduPilot/ardupilot/${COMMIT_HASH}/Tools/scripts/apj_tool.py"
+
+$SUDO wget "$REMOTE_URL_APJ_TOOL" -O "$LOCAL_PATH_APJ_TOOL"
+$SUDO chmod +x "$LOCAL_PATH_APJ_TOOL"


### PR DESCRIPTION
supports injecting them into the .apj firmware for stm32 boards, and creating a .params file in userdata for linux

https://github.com/bluerobotics/BlueOS-docker/assets/4013804/2a471371-c7af-4c92-9682-41fe34638f10

ps: I just increased the width of the select so the full label shows up

additional fix for #1734

this can be tested by running the wizard and chosing a default set, and then resetting the parameters to firmware defaults in qgc and checking if the configuration remains (easier to see frame type in the 3d viewer, for sub at least)

fix #1720 
fix #1722 
fix #1726 