### PR TITLE
core: tools: mavlink-camera-manager: Update to t3.11.6.

### DIFF
--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -5,7 +5,7 @@ set -e
 
 LOCAL_BINARY_PATH="/usr/bin/mavlink-camera-manager"
 ARTIFACT_PREFIX="mavlink-camera-manager"
-VERSION=t3.11.5
+VERSION=t3.11.6
 
 # By default we install armv7
 REMOTE_BINARY_URL="https://github.com/bluerobotics/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-armv7.zip"

--- a/core/tools/mavlink_camera_manager/bootstrap.sh
+++ b/core/tools/mavlink_camera_manager/bootstrap.sh
@@ -8,9 +8,9 @@ ARTIFACT_PREFIX="mavlink-camera-manager"
 VERSION=t3.11.6
 
 # By default we install armv7
-REMOTE_BINARY_URL="https://github.com/bluerobotics/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-armv7.zip"
+REMOTE_BINARY_URL="https://github.com/mavlink/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-armv7.zip"
 if [[ "$(uname -m)" == "x86_64"* ]]; then
-    REMOTE_BINARY_URL="https://github.com/bluerobotics/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-linux-desktop.zip"
+    REMOTE_BINARY_URL="https://github.com/mavlink/mavlink-camera-manager/releases/download/${VERSION}/${ARTIFACT_PREFIX}-linux-desktop.zip"
 fi
 
 # Download and install the camera manager under user binary folder with the correct permissions


### PR DESCRIPTION
Most important changes:
- Fix WebRTC SDP, allowing Redirect 4k RTSP sources to be used with WebRTC
- Fix wrong MAVLink ids, allowing (again) multiple streams with QGC

[Release notes](https://github.com/bluerobotics/mavlink-camera-manager/releases/tag/t3.11.6)