### PR TITLE
Fix two bugs on ParameterEditorDialog

### DIFF
--- a/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
@@ -69,6 +69,7 @@
                   :suffix="param.units"
                   :rules="forcing_input ? [] : [isInRange, isValidType]"
                   @blur="update_variables"
+                  @keyup="isFormValid()"
                 />
 
                 <v-checkbox

--- a/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
+++ b/core/frontend/src/components/parameter-editor/ParameterEditorDialog.vue
@@ -233,6 +233,10 @@ export default Vue.extend({
       return true
     },
     updateSelectedFlags(): void {
+      if (this.new_value < 0) {
+        // No bitmask checking for negative values
+        return
+      }
       const output = []
       for (let v = 0; v < 64; v += 1) {
         const bitmask_value = 2 ** v


### PR DESCRIPTION
fix #1771 and a another bug where we had to click outside of the textfield for the save button to get enabled.