### PR TITLE
bootstrap: bugfix: reboot after ressetting to defaults

### DIFF
--- a/bootstrap/bootstrap/bootstrap.py
+++ b/bootstrap/bootstrap/bootstrap.py
@@ -235,7 +235,6 @@ class Bootstrapper:
                 if time.time() - self.core_last_response_time > 300:
                     print("Core has not responded in 5 minutes, resetting to factory...")
                     self.overwrite_config_file_with_defaults()
-                    continue
                 try:
                     self.remove(image)
                     if self.start(image):


### PR DESCRIPTION
I woke up to this in the morning after setting an invalid image last night:
<img width="457" alt="image" src="https://github.com/bluerobotics/BlueOS-docker/assets/4013804/33ef84e2-acf3-472c-acfd-883aa0a7e4b5">
