### PR TITLE
core: frontend: components: wizard: Move 'start' button the the right side

### DIFF
--- a/core/frontend/src/components/wizard/Wizard.vue
+++ b/core/frontend/src/components/wizard/Wizard.vue
@@ -45,16 +45,16 @@
             </v-card>
             <v-row class="pa-5 justify-space-between">
               <v-btn
-                color="primary"
-                @click="nextStep()"
-              >
-                Start
-              </v-btn>
-              <v-btn
                 color="warning darken"
                 @click="setWizardVersion(); cancel()"
               >
                 Skip Wizard
+              </v-btn>
+              <v-btn
+                color="primary"
+                @click="nextStep()"
+              >
+                Start
               </v-btn>
             </v-row>
           </v-stepper-content>


### PR DESCRIPTION
![image](https://github.com/bluerobotics/BlueOS-docker/assets/1215497/9f9e9b0a-e61f-4d16-ad6f-744e7ba3bc01)

Usually Start / Continue buttons are on the right, and cancel on the left