### PR TITLE
Optimize helper

### DIFF
--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -97,6 +97,14 @@ class ServiceInfo(BaseModel):
     port: int
     metadata: Optional[ServiceMetadata]
 
+    def __hash__(self) -> int:
+        return hash(self.port)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, ServiceInfo):
+            return self.port == other.port
+        return False
+
 
 class SpeedtestServer(BaseModel):
     url: str

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -269,6 +269,7 @@ class Helper:
         return request_response
 
     @staticmethod
+    @temporary_cache(timeout_seconds=1)  # a temporary cache helps us deal with changes in metadata
     # pylint: disable=too-many-branches
     def detect_service(port: int) -> ServiceInfo:
         info = ServiceInfo(valid=False, title="Unknown", documentation_url="", versions=[], port=port)
@@ -361,7 +362,7 @@ class Helper:
         return info
 
     @staticmethod
-    @temporary_cache(timeout_seconds=10)
+    @temporary_cache(timeout_seconds=3)
     def scan_ports() -> List[ServiceInfo]:
         # Get TCP ports that are listen and can be accessed by external users (like server in 0.0.0.0, as described by the LOCALSERVER_CANDIDATES)
         ports = {
@@ -395,6 +396,7 @@ class Helper:
         return [service for service in Helper.KNOWN_SERVICES if service.valid]
 
     @staticmethod
+    @temporary_cache(timeout_seconds=1)
     def check_website(site: Website) -> WebsiteStatus:
         hostname = str(site.value["hostname"])
         port = int(str(site.value["port"]))
@@ -414,6 +416,7 @@ class Helper:
         return website_status
 
     @staticmethod
+    @temporary_cache(timeout_seconds=5)
     def check_internet_access() -> Dict[str, WebsiteStatus]:
         # 10 concurrent executors is fine here because its a very short/light task
         with futures.ThreadPoolExecutor(max_workers=10) as executor:

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -508,7 +508,16 @@ async def internet_test_previous_result() -> Any:
 async def periodic() -> None:
     while True:
         await asyncio.sleep(60)
-        await Helper.check_internet_access()
+        Helper.check_internet_access()
+
+        # Clear the known ports cache and re-scan it
+        if Helper.PERIODICALLY_RESCAN_ALL_SERVICES:
+            Helper.KNOWN_SERVICES.clear()
+        # To get changes in the metadata of extensions, we clear the cache for them to force a rescan
+        elif Helper.PERIODICALLY_RESCAN_3RDPARTY_SERVICES:
+            Helper.KNOWN_SERVICES = {
+                service for service in Helper.KNOWN_SERVICES if service.port in Helper.BLUEOS_SYSTEM_SERVICES_PORTS
+            }
 
 
 app = VersionedFastAPI(

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -34,7 +34,7 @@ HTML_FOLDER = Path.joinpath(Path(__file__).parent.absolute(), "html")
 SPEED_TEST: Optional[Speedtest] = None
 
 
-logging.basicConfig(handlers=[InterceptHandler()], level=0)
+logging.basicConfig(handlers=[InterceptHandler()], level=logging.DEBUG)
 init_logger("Helper")
 
 try:

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -311,7 +311,7 @@ if __name__ == "__main__":
     loop = asyncio.new_event_loop()
 
     # Running uvicorn with log disabled so loguru can handle it
-    config = Config(app=app, loop=loop, host="0.0.0.0", port=81, log_config=None)
+    config = Config(app=app, loop=loop, host="0.0.0.0", port=Helper.PORT, log_config=None)
     server = Server(config)
 
     loop.create_task(periodic())

--- a/core/services/helper/main.py
+++ b/core/services/helper/main.py
@@ -25,10 +25,6 @@ from pydantic import BaseModel
 from speedtest import Speedtest
 from uvicorn import Config, Server
 
-PORT = 81
-DOCS_CANDIDATE_URLS = ["/docs", "/v1.0/ui/"]
-API_CANDIDATE_URLS = ["/docs.json", "/openapi.json", "/swagger.json"]
-
 BLUEOS_VERSION = os.environ.get("GIT_DESCRIBE_TAGS", "null")
 HTML_FOLDER = Path.joinpath(Path(__file__).parent.absolute(), "html")
 SPEED_TEST: Optional[Speedtest] = None
@@ -121,6 +117,9 @@ class SpeedTestResult(BaseModel):
 
 class Helper:
     LOCALSERVER_CANDIDATES = ["0.0.0.0", "::"]
+    DOCS_CANDIDATE_URLS = ["/docs", "/v1.0/ui/"]
+    API_CANDIDATE_URLS = ["/docs.json", "/openapi.json", "/swagger.json"]
+    PORT = 81
     AIOTIMEOUT = aiohttp.ClientTimeout(total=10)
 
     @staticmethod


### PR DESCRIPTION
## Changes

Most of the CPU was spent inside the HTTP requests done by `aiohttp` and `request`. By replacing them with the low-level `http.client`, both the speed and CPU usage were improved.

Closes #1855 

---

All development data and tools can be accessed [here](https://github.com/joaoantoniocardoso/BlueOS-docker/tree/new_helper_dev/core/services/helper/dev_benchmark)

## A/B test:
By doing several runs of the services, the port scanning is not idempotent, meaning that the list of available services can differ from one call to the other.

After analysis, it turns out that the only service that has different outputs is the Ping service (at port `9110`): sometimes it refuses to answer. Increasing the timeouts of the requests of the port_scan, the problem happens less.

Apart from this service, if the skipped ports are ignored, the results are equal both before and after this PR.

## Benchmark

The implementations are:
- `main_opt`: the code on this PR initially
- `main_master`: the code before this PR
- `main_master_with_skip_list`: the skip list patch applied to the code before this PR
- `main_opt2`: the code on this PR, but with [this suggestion](https://github.com/bluerobotics/BlueOS-docker/pull/1857#discussion_r1257488131)
- `main_httpx`: the code on [this other PR](https://github.com/bluerobotics/BlueOS-docker/pull/1858), using httpx to replace both aiohttp and requests
- `main_opt3`: the code on this PR at some point, adding the ethernal cache list suggested by `main_httpx` (disabled during these tests).
- `main_opt4`: the code on this PR at some point, with longer timeouts and 2 concurrent port scans.
- `main_opt4_cached`: the same as the `main_opt4` plus caches added for blueos services and an improved algorithm to decide what ports to scan.

### Speed
![image](https://github.com/bluerobotics/BlueOS-docker/assets/5920286/bfb1455e-cdd9-41bf-ab5d-12ae1cd868da)

![image](https://github.com/bluerobotics/BlueOS-docker/assets/5920286/b57b1087-0ac3-45e9-848c-306e8e588e0c)

### CPU%
![image](https://github.com/bluerobotics/BlueOS-docker/assets/5920286/23f46268-e70c-48cd-9e47-afe4b678a5a7)

![image](https://github.com/bluerobotics/BlueOS-docker/assets/5920286/03305d8c-5d94-41cc-a027-81f8c3b86fc1)


## Summary of improvements

* Speed of `check_internet_access` increased by **132x** on average (of cache hit + miss), and **1.99x** in the worst case (cache miss).
* Speed of `web_services` (the port scan) increased by **58x** on average (of cache hit + miss), and **1.55x** in the worst case (cache miss).
* CPU usage of `check_internet_access` decreased by **1.61x** on average (of cache hit + miss), and **1.71x** in the worst case (cache miss).
* CPU usage of `web_services` decreased by **1.36x** on average (of cache hit + miss), and increased by **0.97x** in the worst case (cache miss).
* Because of the increased timeouts on the port scan requests, it's more forgiven when services are too busy, thus it's more reliable.
* Because of the added and rebalancing in caches, it's more robust and responsive.

